### PR TITLE
Top-bar clearance, persisted zoom, per-site stats, and button move

### DIFF
--- a/frontend/src/components/SiteGroup.tsx
+++ b/frontend/src/components/SiteGroup.tsx
@@ -5,15 +5,26 @@ const SITE_COLORS: string[] = [
   "#3b82f6", "#f59e0b", "#10b981", "#ec4899", "#8b5cf6", "#06b6d4",
 ];
 
+export interface SiteStats {
+  lldp: number;
+  arp: number;
+  discovered: number;
+}
+
 interface SiteProps {
   site: SiteCluster;
   index: number;
   interactive?: boolean;
+  stats?: SiteStats;
   onMouseDown?: (event: MouseEvent<SVGGElement>) => void;
   onResizeMouseDown?: (event: MouseEvent<SVGGElement>) => void;
 }
 
-export function SiteGroup({ site, index, interactive = true, onMouseDown, onResizeMouseDown }: SiteProps) {
+const LLDP_COLOR = "#38bdf8";
+const ARP_COLOR = "#fbbf24";
+const DISCOVERED_COLOR = "#a3e635";
+
+export function SiteGroup({ site, index, interactive = true, stats, onMouseDown, onResizeMouseDown }: SiteProps) {
   const color = SITE_COLORS[index % SITE_COLORS.length];
 
   return (
@@ -42,6 +53,19 @@ export function SiteGroup({ site, index, interactive = true, onMouseDown, onResi
       >
         {site.location}
       </text>
+      {stats && (
+        <text
+          x={site.x + 10}
+          y={site.y + 27}
+          fontSize={8.5}
+          fontWeight={600}
+          fontFamily="system-ui, sans-serif"
+        >
+          <tspan fill={LLDP_COLOR}>LLDP/CDP {stats.lldp}</tspan>
+          <tspan fill={ARP_COLOR} dx={8}>ARP {stats.arp}</tspan>
+          <tspan fill={DISCOVERED_COLOR} dx={8}>Discovered {stats.discovered}</tspan>
+        </text>
+      )}
       {interactive && (
         <g
           onMouseDown={onResizeMouseDown}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent, WheelEvent } from "react";
 import type { TopologyResponse, DeviceSummary } from "@librenms-dash/shared";
 import { useForceLayout } from "@/hooks/useForceLayout";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
-import { useTransformPersistence, readPersistedTransform } from "@/hooks/usePersistedLayout";
+import { useTransformPersistence, readPersistedTransform, clearPersistedTransform } from "@/hooks/usePersistedLayout";
 import { SiteGroup, SiteControls, DeviceGroupBorder } from "./SiteGroup";
 import { OverlayLinkLine } from "./OverlayLink";
 import { HoverableLinkPath } from "./HoverableLinkPath";
@@ -54,6 +54,11 @@ function snapToNearby(value: number, candidates: number[]): number | null {
 
 export function TopologyMap({ data }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const topBarRef = useRef<HTMLDivElement>(null);
+  // Vertical space the floating top bars occupy, so the layout never places
+  // content under them. Measured at runtime since the bars wrap (and grow
+  // taller) on narrow screens.
+  const [topInset, setTopInset] = useState(56);
   // True on devices with a real hover pointer (desktop); false on touch screens.
   const canHover = useMemo(
     () => typeof window === "undefined" || !window.matchMedia ? true : window.matchMedia("(hover: hover)").matches,
@@ -89,8 +94,12 @@ export function TopologyMap({ data }: Props) {
   const alertTooltipHovered = useRef(false);
 
   // Seed viewport transform from localStorage on first render, then persist changes.
-  const [transform, setTransform] = useState(() => readPersistedTransform() ?? { x: 0, y: 0, scale: 1 });
+  const restoredTransformRef = useRef(readPersistedTransform());
+  const [transform, setTransform] = useState(() => restoredTransformRef.current ?? { x: 0, y: 0, scale: 1 });
   const lastInitialScaleRef = useRef(1);
+  // When a transform was restored from localStorage, don't let auto-fit override
+  // it — so a refresh preserves the saved zoom/pan. Cleared on Reset Layout.
+  const suppressAutoFit = useRef(restoredTransformRef.current != null);
   // Debounce-write the transform so pan/zoom doesn't hammer localStorage on every frame.
   useTransformPersistence(transform);
 
@@ -120,6 +129,19 @@ export function TopologyMap({ data }: Props) {
     return () => ro.disconnect();
   }, []);
 
+  // Track the top bars' height (they wrap on small screens) and reserve that
+  // much space at the top of the layout, plus a small gap.
+  useEffect(() => {
+    const el = topBarRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      // offsetHeight includes the wrapper padding, so this is the full footprint.
+      setTopInset((el.offsetHeight || 56) + 8);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const {
     nodes,
     links,
@@ -134,13 +156,14 @@ export function TopologyMap({ data }: Props) {
     moveDevice,
     resizeSite,
     toggleSiteOrientation,
-  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices);
+  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices, topInset);
 
   // When the layout regenerates (new topology, orientation change, reset), snap
   // the SVG transform back to the computed fit-scale so nothing overflows.
   useEffect(() => {
     if (initialScale === lastInitialScaleRef.current) return;
     lastInitialScaleRef.current = initialScale;
+    if (suppressAutoFit.current) return;
     setTransform({ x: 0, y: 0, scale: initialScale });
   }, [initialScale]);
 
@@ -453,13 +476,43 @@ export function TopologyMap({ data }: Props) {
     setHiddenOverlays((prev) => ({ ...prev, [type]: !prev[type] }));
   }, []);
 
+  const handleReset = useCallback(() => {
+    // Reset Layout should also discard a saved zoom/pan and snap back to fit.
+    suppressAutoFit.current = false;
+    clearPersistedTransform();
+    resetLayout();
+    setTransform({ x: 0, y: 0, scale: initialScale });
+  }, [resetLayout, initialScale]);
+
+  // Per-location counts shown in each site header. Neighbor/ARP links are always
+  // computed (independent of the visibility toggles); discovered devices come
+  // straight from the source data so the count shows even when the layer is off.
+  const siteStats = useMemo(() => {
+    const map = new Map<string, { lldp: number; arp: number; discovered: number }>();
+    const bucket = (id: string) => {
+      let s = map.get(id);
+      if (!s) { s = { lldp: 0, arp: 0, discovered: 0 }; map.set(id, s); }
+      return s;
+    };
+    // Seed every site so the header shows counts (including zeros) for all locations.
+    for (const site of data.sites) bucket(site.id);
+    for (const nl of neighborLinks) {
+      for (const id of new Set([nl.source.siteId, nl.target.siteId])) bucket(id).lldp++;
+    }
+    for (const al of arpLinks) {
+      for (const id of new Set([al.source.siteId, al.target.siteId])) bucket(id).arp++;
+    }
+    for (const ad of (data.arpDevices ?? [])) bucket(ad.siteId).discovered++;
+    return map;
+  }, [neighborLinks, arpLinks, data.arpDevices, data.sites]);
+
   return (
     <div ref={containerRef} className="w-full h-full relative">
       {/* Top floating bars — single flex row keeps left/right bars equal-height
           (items-stretch) and never overlapping (justify-between; outer flex-wrap
           drops the right bar below the left on very narrow screens). The wrapper
           is pointer-transparent so panning still works in the gap between bars. */}
-      <div className="absolute top-0 inset-x-0 z-10 p-4 flex flex-wrap items-stretch justify-between gap-3 pointer-events-none">
+      <div ref={topBarRef} className="absolute top-0 inset-x-0 z-10 p-4 flex flex-wrap items-stretch justify-between gap-3 pointer-events-none">
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-3 bg-gray-900/90 backdrop-blur border border-gray-700 rounded-lg px-4 py-2 pointer-events-auto">
         <button
@@ -492,21 +545,6 @@ export function TopologyMap({ data }: Props) {
           />
           Discovered ({data.arpDevices?.length ?? 0})
         </button>
-        <button
-          onClick={() => setSnapToGrid((v) => !v)}
-          title="Enable to move and resize boxes (with grid snapping)"
-          className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ${
-            snapToGrid ? "bg-gray-700 text-white" : "bg-gray-800 text-gray-500"
-          }`}
-        >
-          <span className="grid grid-cols-2 gap-0.5">
-            <span className="w-1 h-1 rounded-sm bg-current" />
-            <span className="w-1 h-1 rounded-sm bg-current" />
-            <span className="w-1 h-1 rounded-sm bg-current" />
-            <span className="w-1 h-1 rounded-sm bg-current" />
-          </span>
-          Edit Layout
-        </button>
         <span className="text-gray-600">|</span>
         <span className="text-xs text-gray-400 font-semibold mr-2">Overlays:</span>
         {data.overlays.map((o) => {
@@ -529,8 +567,23 @@ export function TopologyMap({ data }: Props) {
           );
         })}
         <button
-          onClick={resetLayout}
-          className="text-xs px-2 py-1 rounded bg-gray-800 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors ml-2"
+          onClick={() => setSnapToGrid((v) => !v)}
+          title="Enable to move and resize boxes (with grid snapping)"
+          className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ml-2 ${
+            snapToGrid ? "bg-gray-700 text-white" : "bg-gray-800 text-gray-500"
+          }`}
+        >
+          <span className="grid grid-cols-2 gap-0.5">
+            <span className="w-1 h-1 rounded-sm bg-current" />
+            <span className="w-1 h-1 rounded-sm bg-current" />
+            <span className="w-1 h-1 rounded-sm bg-current" />
+            <span className="w-1 h-1 rounded-sm bg-current" />
+          </span>
+          Edit Layout
+        </button>
+        <button
+          onClick={handleReset}
+          className="text-xs px-2 py-1 rounded bg-gray-800 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
         >
           Reset Layout
         </button>
@@ -589,6 +642,7 @@ export function TopologyMap({ data }: Props) {
               site={site}
               index={i}
               interactive={snapToGrid}
+              stats={siteStats.get(site.id)}
               onMouseDown={(e) => beginSiteDrag(site.id, e)}
               onResizeMouseDown={(e) => beginSiteResize(site.id, e)}
             />

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -161,6 +161,7 @@ function layoutAll(
   siteOrientations: Record<string, SiteOrientation> = {},
   showArpDevices = false,
   viewH = 800,
+  topReserve = 56,
 ): { sites: SiteCluster[]; nodes: LayoutNode[]; links: LayoutLink[]; neighborLinks: NeighborLayoutLink[]; arpLinks: ArpLayoutLink[]; deviceGroups: DeviceGroup[]; arpDeviceNodes: ArpDeviceLayoutNode[]; initialScale: number } {
 
   // Sort sites: largest first
@@ -211,8 +212,8 @@ function layoutAll(
   }
 
   // Determine placement: try to fit all sites within viewW × viewH.
-  // Reserve space for the top control bar (~56px).
-  const TOP_RESERVE = 56;
+  // Reserve space for the top control bars (measured at runtime, defaults to ~56px).
+  const TOP_RESERVE = topReserve;
   const usableH = Math.max(viewH - TOP_RESERVE, 300);
   const usableW = Math.max(viewW, 400);
 
@@ -627,13 +628,14 @@ function layoutSignature(
   containerHeight: number,
   siteOrientations: Record<string, SiteOrientation>,
   showArpDevices: boolean,
+  topReserve: number,
 ): string {
   const sites = data.sites
     .map((s) => `${s.id}:${s.devices.map((d) => d.hostname).sort().join(",")}`)
     .sort()
     .join("|");
   const arp = (data.arpDevices ?? []).map((a) => a.mac).sort().join(",");
-  return `${sites}#${arp}@${containerWidth}x${containerHeight}|${JSON.stringify(siteOrientations)}|${showArpDevices}`;
+  return `${sites}#${arp}@${containerWidth}x${containerHeight}|${JSON.stringify(siteOrientations)}|${showArpDevices}|${topReserve}`;
 }
 
 export function useForceLayout(
@@ -641,6 +643,7 @@ export function useForceLayout(
   containerWidth: number,
   containerHeight: number,
   showArpDevices = false,
+  topReserve = 56,
 ) {
   const persist = usePersistedLayout();
 
@@ -690,10 +693,10 @@ export function useForceLayout(
     if (!data || !containerWidth) return;
     // Skip regenerating the layout (which discards manual drags/resizes) when the
     // topology and layout inputs are unchanged — e.g. on the 5-minute background poll.
-    const sig = layoutSignature(data, containerWidth, containerHeight, siteOrientations, showArpDevices);
+    const sig = layoutSignature(data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve);
     if (sig === layoutSigRef.current) return;
     layoutSigRef.current = sig;
-    const result = layoutAll(data, containerWidth, siteOrientations, showArpDevices, containerHeight);
+    const result = layoutAll(data, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
     // Overlay saved positions on top of freshly-computed ones so manual drags
     // and resizes from a previous session are restored after reload.
     const restoredSites = persist.applySitePositions(result.sites);
@@ -721,15 +724,15 @@ export function useForceLayout(
     setArpDeviceNodes(arp.arpNodes);
     setDeviceGroups(restoredGroups);
     setInitialScale(result.initialScale);
-  }, [data, containerWidth, siteOrientations, showArpDevices]);
+  }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve]);
 
   const resetLayout = useCallback(() => {
     if (!data || !containerWidth) return;
     // Wipe saved positions so reset truly goes back to auto-layout.
     persist.clearPersistedLayout();
     setSiteOrientations({});
-    layoutSigRef.current = layoutSignature(data, containerWidth, containerHeight, {}, showArpDevices);
-    const result = layoutAll(data, containerWidth, {}, showArpDevices, containerHeight);
+    layoutSigRef.current = layoutSignature(data, containerWidth, containerHeight, {}, showArpDevices, topReserve);
+    const result = layoutAll(data, containerWidth, {}, showArpDevices, containerHeight, topReserve);
     setSites(result.sites);
     setNodes(result.nodes);
     setLinks(result.links);
@@ -738,7 +741,7 @@ export function useForceLayout(
     setArpDeviceNodes(result.arpDeviceNodes);
     setDeviceGroups(result.deviceGroups);
     setInitialScale(result.initialScale);
-  }, [data, containerWidth, showArpDevices]);
+  }, [data, containerWidth, containerHeight, showArpDevices, topReserve]);
 
   const toggleSiteOrientation = useCallback((siteId: string) => {
     setSiteOrientations((prev) => {


### PR DESCRIPTION
## Overview
Four topology-map UI/UX improvements, built and verified via `docker-compose build`.

## What changed
- **No content under the top bars** — the layout reserved a hardcoded 56px at the top, which wasn't enough once the floating left/right bars wrap and grow taller on narrow screens. The actual top-bar height is now measured at runtime (`ResizeObserver` on the bar wrapper, `offsetHeight` + 8px gap) and threaded through `useForceLayout` → `layoutAll` as the top inset, so sites never render beneath the bars.
- **Zoom/pan persists across refresh** — the viewport transform was already saved to `localStorage`, but a fit-scale auto-fit effect was overwriting it on the first layout pass. Auto-fit is now suppressed when a transform was restored; **Reset Layout** clears the saved transform and refits.
- **Per-location stats in site headers** — each site header shows a second line: `LLDP/CDP n` (sky), `ARP n` (amber), `Discovered n` (lime). Link counts are attributed by either endpoint's site; discovered count comes straight from source data so it shows even when the layer is toggled off.
- **Edit Layout button moved** next to **Reset Layout** in the controls bar.

## Why
These address overlap/clipping on small/mobile screens, make the view survive refreshes, and surface per-site connectivity counts at a glance.

## Reviewer notes
- The four changes are interleaved in `TopologyMap.tsx`, so they're in a single commit rather than one-per-fix.
- Auto-fit suppression means that if the topology structure changes between sessions, a restored zoom may no longer frame everything — **Reset Layout** restores the fit.
- Verified: Docker build passes (`tsc -b` clean), container serves `/` and `/api/topology` with `200`, and the new code is present in the built bundle. Visual behaviors (narrow-viewport overlap, zoom-on-refresh, header counts) are best confirmed in a browser.