### PR TITLE
Overlay subnet fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# LibreNMS-Dash
+<p align="center">
+  <img src="frontend/public/favicon.svg" width="80" alt="LibreNMS-Dash logo" />
+</p>
 
-LibreNMS-Dash is a LibreNMS-backed network dashboard. It aggregates devices, sites, overlays, alerts, and graphs into a single topology view with live hover details and SVG-based layout controls.
+<h1 align="center">
+  <img src="https://img.shields.io/badge/LibreNMS-74b743?style=flat-square&logoColor=white" alt="LibreNMS" height="24" />
+  <img src="https://img.shields.io/badge/-Dash-334155?style=flat-square" alt="Dash" height="24" />
+</h1>
+
+<p align="center">
+  <a href="https://github.com/jaykumar2001/Librenms-dash"><img src="https://img.shields.io/badge/license-GPLv3-blue.svg" alt="License" /></a>
+</p>
+
+**LibreNMS-Dash** is a LibreNMS-backed network dashboard. It aggregates devices, sites, overlays, alerts, and graphs into a single topology view with live hover details and SVG-based layout controls.
 
 ## What It Shows
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -30,7 +30,7 @@ export const OVERLAY_SUBNETS: Record<OverlayType, string[]> = {
 
 // Docker bridge subnets — containers on these ranges are excluded from ARP
 // discovery. Defaults to the standard Docker bridge pool (172.16.0.0/12).
-export const DOCKER_SUBNETS = parseSubnetList(process.env.DOCKER_SUBNETS, ["172.16.0.0/12"]);
+export const DOCKER_SUBNETS = parseSubnetList(process.env.DOCKER_SUBNETS, ["172.17.0.0/16"]);
 
 // Extra prefixes treated as infrastructure / non-discoverable when scanning ARP
 // tables (in addition to the overlay subnets above). Defaults to loopback and

--- a/backend/src/librenms/overlays.ts
+++ b/backend/src/librenms/overlays.ts
@@ -195,7 +195,7 @@ export function findLanIp(deviceIp: string, ips: LnmsDeviceIp[]): string {
 }
 
 const OVERLAY_IFACE_RE = /^(zt|wg|tailscale|docker)/i;
-const DOCKER_IFACE_RE = /^(br-|docker|veth)/i;
+const DOCKER_IFACE_RE = /^(br-[0-9a-f]{6,}|docker|veth)/i;
 const isDockerIp = makeCidrMatcher(DOCKER_SUBNETS);
 
 function isExcludedIface(ifName: string): boolean {

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -1,9 +1,15 @@
 import { Hono } from "hono";
+import { execSync } from "node:child_process";
 import { cache } from "../cache/store.js";
 import type { TopologyResponse, Site, DeviceSummary, OverlayGroup, NeighborLink, ArpLink, ArpDiscoveredDevice, DeviceRoute } from "@librenms-dash/shared";
 import type { LnmsDevice, LnmsPort, LnmsLocation, LnmsAlert, LnmsDeviceIp, LnmsLink } from "../librenms/types.js";
 import { getOverlayPortSummaries, findLanIp, findDeviceIps } from "../librenms/overlays.js";
 import { normalizeMac } from "../librenms/oui.js";
+
+let commitSha: string | undefined;
+try {
+  commitSha = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+} catch { /* not a git repo or git unavailable */ }
 
 const app = new Hono();
 
@@ -139,6 +145,7 @@ app.get("/", (c) => {
       timestamp: a.timestamp,
     })),
     lastUpdated: new Date().toISOString(),
+    commitSha,
   };
 
   return c.json(response);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>LibreNMS-Dash — Network Dashboard</title>
   </head>
   <body class="bg-gray-950 text-gray-100 m-0 overflow-hidden">

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg width="32" height="32" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="60" cy="60" r="56" stroke="#74b743" stroke-width="4" stroke-opacity="0.7"/>
+  <line x1="60" y1="36" x2="36" y2="68" stroke="#74b743" stroke-width="3" stroke-opacity="0.5"/>
+  <line x1="60" y1="36" x2="84" y2="68" stroke="#74b743" stroke-width="3" stroke-opacity="0.5"/>
+  <line x1="36" y1="68" x2="84" y2="68" stroke="#74b743" stroke-width="3" stroke-opacity="0.5"/>
+  <circle cx="60" cy="36" r="12" fill="#74b743" fill-opacity="0.15" stroke="#74b743" stroke-width="3"/>
+  <circle cx="60" cy="36" r="5" fill="#74b743"/>
+  <circle cx="36" cy="68" r="10" fill="#38bdf8" fill-opacity="0.1" stroke="#38bdf8" stroke-width="2.5"/>
+  <circle cx="36" cy="68" r="4.5" fill="#38bdf8"/>
+  <circle cx="84" cy="68" r="10" fill="#fbbf24" fill-opacity="0.1" stroke="#fbbf24" stroke-width="2.5"/>
+  <circle cx="84" cy="68" r="4.5" fill="#fbbf24"/>
+  <rect x="50" y="96" width="6" height="14" rx="1.5" fill="#74b743" fill-opacity="0.6"/>
+  <rect x="57" y="91" width="6" height="19" rx="1.5" fill="#74b743" fill-opacity="0.8"/>
+  <rect x="64" y="93" width="6" height="17" rx="1.5" fill="#74b743" fill-opacity="0.7"/>
+</svg>

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { Logo } from "./Logo";
 
 export function LoginPage() {
   const { login } = useAuth();
@@ -24,7 +25,10 @@ export function LoginPage() {
   return (
     <div className="w-full max-w-sm mx-auto">
         <div className="text-center mb-8">
-          <h1 className="text-xl font-semibold text-white mb-2">LibreNMS Dash</h1>
+          <Logo size={72} className="mx-auto mb-3" />
+          <h1 className="text-xl font-semibold text-white mb-2">
+            <span style={{ color: "#74b743" }}>LibreNMS</span> Dash
+          </h1>
           <p className="text-gray-400 text-sm">Sign in to view the topology dashboard</p>
         </div>
 
@@ -71,6 +75,19 @@ export function LoginPage() {
             {isSubmitting ? "Signing in..." : "Sign in"}
           </button>
         </form>
+
+        <div className="mt-8 text-center text-[10px] text-gray-500">
+          <span>© {new Date().getFullYear()} GPLv3</span>
+          <span className="text-gray-700 mx-1">·</span>
+          <a
+            href="https://github.com/jaykumar2001/Librenms-dash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gray-300 transition-colors underline underline-offset-2"
+          >
+            GitHub
+          </a>
+        </div>
     </div>
   );
 }

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,57 @@
+interface Props {
+  size?: number;
+  className?: string;
+}
+
+export function Logo({ size = 40, className }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      {/* Outer ring — dark border with subtle green glow */}
+      <circle cx="60" cy="60" r="56" stroke="#74b743" strokeWidth="2.5" strokeOpacity="0.35" />
+      <circle cx="60" cy="60" r="56" stroke="#74b743" strokeWidth="0.8" strokeOpacity="0.7" />
+
+      {/* Network links — connecting the nodes */}
+      <line x1="60" y1="36" x2="36" y2="68" stroke="#74b743" strokeWidth="2" strokeOpacity="0.5" />
+      <line x1="60" y1="36" x2="84" y2="68" stroke="#74b743" strokeWidth="2" strokeOpacity="0.5" />
+      <line x1="36" y1="68" x2="84" y2="68" stroke="#74b743" strokeWidth="2" strokeOpacity="0.5" />
+      <line x1="36" y1="68" x2="44" y2="90" stroke="#38bdf8" strokeWidth="1.5" strokeOpacity="0.4" />
+      <line x1="84" y1="68" x2="76" y2="90" stroke="#fbbf24" strokeWidth="1.5" strokeOpacity="0.4" />
+      <line x1="60" y1="36" x2="60" y2="20" stroke="#74b743" strokeWidth="1.5" strokeOpacity="0.3" />
+
+      {/* Central hub node — bright green */}
+      <circle cx="60" cy="36" r="10" fill="#74b743" fillOpacity="0.15" stroke="#74b743" strokeWidth="2" />
+      <circle cx="60" cy="36" r="4" fill="#74b743" />
+
+      {/* Left node */}
+      <circle cx="36" cy="68" r="8" fill="#38bdf8" fillOpacity="0.1" stroke="#38bdf8" strokeWidth="1.5" />
+      <circle cx="36" cy="68" r="3.5" fill="#38bdf8" />
+
+      {/* Right node */}
+      <circle cx="84" cy="68" r="8" fill="#fbbf24" fillOpacity="0.1" stroke="#fbbf24" strokeWidth="1.5" />
+      <circle cx="84" cy="68" r="3.5" fill="#fbbf24" />
+
+      {/* Leaf nodes — discovered/edge devices */}
+      <circle cx="44" cy="90" r="4" fill="#38bdf8" fillOpacity="0.12" stroke="#38bdf8" strokeWidth="1" />
+      <circle cx="44" cy="90" r="2" fill="#38bdf8" fillOpacity="0.7" />
+
+      <circle cx="76" cy="90" r="4" fill="#fbbf24" fillOpacity="0.12" stroke="#fbbf24" strokeWidth="1" />
+      <circle cx="76" cy="90" r="2" fill="#fbbf24" fillOpacity="0.7" />
+
+      {/* Top pulse — signal indicator */}
+      <circle cx="60" cy="20" r="3" fill="none" stroke="#74b743" strokeWidth="1" strokeOpacity="0.5" />
+      <circle cx="60" cy="20" r="1.5" fill="#74b743" fillOpacity="0.6" />
+
+      {/* Dashboard bars at bottom center — the "Dash" element */}
+      <rect x="52" y="100" width="4" height="10" rx="1" fill="#74b743" fillOpacity="0.6" />
+      <rect x="58" y="96" width="4" height="14" rx="1" fill="#74b743" fillOpacity="0.8" />
+      <rect x="64" y="98" width="4" height="12" rx="1" fill="#74b743" fillOpacity="0.7" />
+    </svg>
+  );
+}

--- a/frontend/src/components/SiteGroup.tsx
+++ b/frontend/src/components/SiteGroup.tsx
@@ -9,6 +9,7 @@ export interface SiteStats {
   lldp: number;
   arp: number;
   discovered: number;
+  routes: number;
 }
 
 interface SiteProps {
@@ -23,6 +24,7 @@ interface SiteProps {
 const LLDP_COLOR = "#38bdf8";
 const ARP_COLOR = "#fbbf24";
 const DISCOVERED_COLOR = "#a3e635";
+const ROUTES_COLOR = "#34d399";
 
 export function SiteGroup({ site, index, interactive = true, stats, onMouseDown, onResizeMouseDown }: SiteProps) {
   const color = SITE_COLORS[index % SITE_COLORS.length];
@@ -45,27 +47,18 @@ export function SiteGroup({ site, index, interactive = true, stats, onMouseDown,
       <text
         x={site.x + 10}
         y={site.y + 15}
-        fill={color}
-        fillOpacity={0.9}
-        fontSize={12}
-        fontWeight={700}
         fontFamily="system-ui, sans-serif"
       >
-        {site.location}
+        <tspan fill={color} fillOpacity={0.9} fontSize={12} fontWeight={700}>{site.location}</tspan>
+        {stats && (
+          <>
+            <tspan fill={ROUTES_COLOR} dx={10} fontSize={8.5} fontWeight={600}>Routes {stats.routes}</tspan>
+            <tspan fill={LLDP_COLOR} dx={8} fontSize={8.5} fontWeight={600}>LLDP/CDP {stats.lldp}</tspan>
+            <tspan fill={ARP_COLOR} dx={8} fontSize={8.5} fontWeight={600}>ARP {stats.arp}</tspan>
+            <tspan fill={DISCOVERED_COLOR} dx={8} fontSize={8.5} fontWeight={600}>Discovered {stats.discovered}</tspan>
+          </>
+        )}
       </text>
-      {stats && (
-        <text
-          x={site.x + 10}
-          y={site.y + 27}
-          fontSize={8.5}
-          fontWeight={600}
-          fontFamily="system-ui, sans-serif"
-        >
-          <tspan fill={LLDP_COLOR}>LLDP/CDP {stats.lldp}</tspan>
-          <tspan fill={ARP_COLOR} dx={8}>ARP {stats.arp}</tspan>
-          <tspan fill={DISCOVERED_COLOR} dx={8}>Discovered {stats.discovered}</tspan>
-        </text>
-      )}
       {interactive && (
         <g
           onMouseDown={onResizeMouseDown}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -12,6 +12,7 @@ import { ArpDeviceNode } from "./ArpDeviceNode";
 import { DevicePopover } from "./DevicePopover";
 import { LinkTooltip, type LinkTooltipData } from "./LinkTooltip";
 import { curvedLinkPath, pointToPointPath, computeDominantSide, DEVICE_HALF, ARP_HALF, type Side } from "@/lib/linkGeometry";
+import { Logo } from "./Logo";
 
 interface Props {
   data: TopologyResponse;
@@ -97,6 +98,18 @@ export function TopologyMap({ data }: Props) {
   const alertHoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const alertDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const alertTooltipHovered = useRef(false);
+  const prevCommitSha = useRef(data.commitSha);
+  const [shaChanged, setShaChanged] = useState(false);
+
+  useEffect(() => {
+    if (prevCommitSha.current && data.commitSha && prevCommitSha.current !== data.commitSha) {
+      setShaChanged(true);
+      const timer = setTimeout(() => setShaChanged(false), 15000);
+      prevCommitSha.current = data.commitSha;
+      return () => clearTimeout(timer);
+    }
+    prevCommitSha.current = data.commitSha;
+  }, [data.commitSha]);
 
   // After login, fit to screen instead of restoring a saved zoom/pan.
   const useFitTransformRef = useRef(consumeFitTransformRequest());
@@ -622,14 +635,17 @@ export function TopologyMap({ data }: Props) {
   // computed (independent of the visibility toggles); discovered devices come
   // straight from the source data so the count shows even when the layer is off.
   const siteStats = useMemo(() => {
-    const map = new Map<string, { lldp: number; arp: number; discovered: number }>();
+    const map = new Map<string, { lldp: number; arp: number; discovered: number; routes: number }>();
     const bucket = (id: string) => {
       let s = map.get(id);
-      if (!s) { s = { lldp: 0, arp: 0, discovered: 0 }; map.set(id, s); }
+      if (!s) { s = { lldp: 0, arp: 0, discovered: 0, routes: 0 }; map.set(id, s); }
       return s;
     };
     // Seed every site so the header shows counts (including zeros) for all locations.
-    for (const site of data.sites) bucket(site.id);
+    for (const site of data.sites) {
+      const b = bucket(site.id);
+      for (const dev of site.devices) b.routes += dev.routes?.length ?? 0;
+    }
     for (const nl of neighborLinks) {
       for (const id of new Set([nl.source.siteId, nl.target.siteId])) bucket(id).lldp++;
     }
@@ -639,6 +655,14 @@ export function TopologyMap({ data }: Props) {
     for (const ad of (data.arpDevices ?? [])) bucket(ad.siteId).discovered++;
     return map;
   }, [neighborLinks, arpLinks, data.arpDevices, data.sites]);
+
+  const totalRoutes = useMemo(() => {
+    let count = 0;
+    for (const site of data.sites) {
+      for (const dev of site.devices) count += dev.routes?.length ?? 0;
+    }
+    return count;
+  }, [data.sites]);
 
   return (
     <div ref={containerRef} className="w-full h-full relative">
@@ -679,6 +703,10 @@ export function TopologyMap({ data }: Props) {
           />
           Discovered ({data.arpDevices?.length ?? 0})
         </button>
+        <span className="flex items-center gap-1.5 text-xs px-2 py-1 rounded bg-gray-800 text-gray-400">
+          <span className="w-2 h-2 inline-block rounded-full" style={{ backgroundColor: "#34d399" }} />
+          Routes ({totalRoutes})
+        </span>
         <span className="text-gray-600">|</span>
         <span className="text-xs text-gray-400 font-semibold mr-2">Overlays:</span>
         {data.overlays.map((o) => {
@@ -1153,6 +1181,38 @@ export function TopologyMap({ data }: Props) {
           </table>
         </div>
       )}
+
+      {/* Top-right: Logo */}
+      <div className="absolute top-4 right-4 z-10 pointer-events-none">
+        <Logo size={48} />
+      </div>
+
+      {/* Bottom-right: GPLv3 copyright, GitHub link, commit SHA */}
+      <div className="absolute bottom-2 right-2 z-10 pointer-events-auto flex items-center gap-2 text-[10px] text-gray-500">
+        <span>© {new Date().getFullYear()} GPLv3</span>
+        <span className="text-gray-700">·</span>
+        <a
+          href="https://github.com/jaykumar2001/Librenms-dash"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-gray-300 transition-colors underline underline-offset-2"
+        >
+          GitHub
+        </a>
+        {data.commitSha && (
+          <>
+            <span className="text-gray-700">·</span>
+            <a
+              href={`https://github.com/jaykumar2001/Librenms-dash/commit/${data.commitSha}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`font-mono transition-colors ${shaChanged ? "text-yellow-400 font-bold animate-pulse" : "hover:text-gray-300"}`}
+            >
+              {data.commitSha}
+            </a>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -161,6 +161,7 @@ export interface TopologyResponse {
   arpDevices: ArpDiscoveredDevice[];
   alerts: Alert[];
   lastUpdated: string;
+  commitSha?: string;
 }
 
 export interface DeviceOverview {


### PR DESCRIPTION
Root cause: findDeviceIps() was filtering out all IPs from OpenWrt's br-lan interface because the regex /^(br-|docker|veth)/i matched br-lan. Docker bridges are actually named
br-<12hexchars> (e.g., br-a1b2c3d4e5f6), not br-lan.

Fix 1 — overlays.ts:198: Changed DOCKER_IFACE_RE from /^(br-|docker|veth)/i to /^(br-[0-9a-f]{6,}|docker|veth)/i. Now only matches Docker-style hex bridge names, not OpenWrt's
br-lan/br-guest.

Fix 2 — config.ts:33: Narrowed default DOCKER_SUBNETS from 172.16.0.0/12 to 172.17.0.0/16. The /12 range covers all of 172.16–172.31.* which many networks use as legitimate LANs.
Docker's actual default bridge is 172.17.0.0/16.