### PR TITLE
Asset change detection with SSE streaming

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import deviceRoutes from "./routes/devices.js";
 import graphRoutes from "./routes/graphs.js";
 import portRoutes from "./routes/ports.js";
 import authRoutes from "./routes/auth.js";
+import eventRoutes from "./routes/events.js";
 import { requireAuth } from "./middleware/auth.js";
 
 const app = new Hono();
@@ -44,6 +45,7 @@ app.route("/api/topology", topologyRoutes);
 app.route("/api/devices", deviceRoutes);
 app.route("/api/graph", graphRoutes);
 app.route("/api/ports", portRoutes);
+app.route("/api/events", eventRoutes);
 
 if (process.env.NODE_ENV === "production") {
   app.use("/*", serveStatic({ root: "./frontend/dist" }));

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -41,10 +41,17 @@ const assetBaseline = new Set<string>();
 let eventSeq = 0;
 const MAX_EVENTS = 200;
 
+type EventListener = (events: AssetEvent[]) => void;
+const sseListeners = new Set<EventListener>();
+
+export function subscribeEvents(fn: EventListener) { sseListeners.add(fn); }
+export function unsubscribeEvents(fn: EventListener) { sseListeners.delete(fn); }
+
 function pushEvents(events: AssetEvent[]) {
   if (events.length === 0) return;
   const existing = cache.get<AssetEvent[]>("assetEvents") ?? [];
   cache.set("assetEvents", [...existing, ...events].slice(-MAX_EVENTS), 60 * 60 * 1000);
+  for (const fn of sseListeners) fn(events);
 }
 
 function diffAndLog(category: string, prev: Set<string>, curr: Set<string>): Set<string> {

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -6,7 +6,7 @@ import { makeCidrMatcher } from "../librenms/cidr.js";
 import { ARP_EXCLUDED_SUBNETS, OVERLAY_SUBNETS } from "../config.js";
 import { initWebSession, isWebClientEnabled, fetchRoutes, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
 import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry } from "../librenms/types.js";
-import type { ArpLink, ArpDiscoveredDevice, DeviceRoute } from "@librenms-dash/shared";
+import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent } from "@librenms-dash/shared";
 
 const STAGGER_MS = 200;
 
@@ -21,6 +21,53 @@ const isExcludedArpIp = makeCidrMatcher([
   ...ARP_EXCLUDED_SUBNETS,
   ...Object.values(OVERLAY_SUBNETS).flat(),
 ]);
+
+// --- Asset change detection ---
+const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+function localTimestamp(): string {
+  return new Date().toLocaleString("sv-SE", { timeZone: localTz });
+}
+
+const prevAssets = {
+  devices: new Set<string>(),
+  ports: new Set<string>(),
+  ips: new Set<string>(),
+  overlayLinks: new Set<string>(),
+  arpDevices: new Set<string>(),
+  routes: new Set<string>(),
+};
+const assetBaseline = new Set<string>();
+let eventSeq = 0;
+const MAX_EVENTS = 200;
+
+function pushEvents(events: AssetEvent[]) {
+  if (events.length === 0) return;
+  const existing = cache.get<AssetEvent[]>("assetEvents") ?? [];
+  cache.set("assetEvents", [...existing, ...events].slice(-MAX_EVENTS), 60 * 60 * 1000);
+}
+
+function diffAndLog(category: string, prev: Set<string>, curr: Set<string>): Set<string> {
+  if (assetBaseline.has(category)) {
+    const ts = localTimestamp();
+    const events: AssetEvent[] = [];
+    for (const key of curr) {
+      if (!prev.has(key)) {
+        console.log(`${ts} [asset+] ${category} added: ${key}`);
+        events.push({ id: ++eventSeq, timestamp: new Date().toISOString(), action: "added", category, asset: key });
+      }
+    }
+    for (const key of prev) {
+      if (!curr.has(key)) {
+        console.log(`${ts} [asset-] ${category} removed: ${key}`);
+        events.push({ id: ++eventSeq, timestamp: new Date().toISOString(), action: "removed", category, asset: key });
+      }
+    }
+    pushEvents(events);
+  }
+  assetBaseline.add(category);
+  return curr;
+}
 
 async function fetchDevices(): Promise<LnmsDevice[]> {
   const res = await librenmsGet<{ devices: LnmsDevice[] }>("/devices");
@@ -65,6 +112,9 @@ export async function pollDevicesAndLocations() {
   cache.set("links", links, TTL.DEVICES);
   const skipped = allDevices.length - devices.length;
   console.log(`[poller] Cached ${devices.length} devices (${skipped} disabled/ignored skipped), ${locations.length} locations, ${links.length} neighbor links`);
+
+  const currDevices = new Set(devices.map(d => `${d.hostname} (${d.ip})`));
+  prevAssets.devices = diffAndLog("device", prevAssets.devices, currDevices);
 }
 
 export async function pollPortsAndIps() {
@@ -95,6 +145,23 @@ export async function pollPortsAndIps() {
   const overlays = buildOverlayLinks(allPorts, allIps);
   cache.set("overlays", overlays, TTL.PORTS);
   console.log(`[poller] Cached overlays: ${overlays.map((o) => `${o.type}(${o.links.length} links)`).join(", ")}`);
+
+  const currPorts = new Set<string>();
+  const currIps = new Set<string>();
+  for (const [hostname, ports] of allPorts) {
+    for (const p of ports) if (p.ifName) currPorts.add(`${hostname}/${p.ifName}`);
+  }
+  for (const [hostname, ips] of allIps) {
+    for (const ip of ips) if (ip.ipv4_address) currIps.add(`${hostname} ${ip.ipv4_address}`);
+  }
+  prevAssets.ports = diffAndLog("port", prevAssets.ports, currPorts);
+  prevAssets.ips = diffAndLog("ip", prevAssets.ips, currIps);
+
+  const currOverlays = new Set<string>();
+  for (const g of overlays) {
+    for (const l of g.links) currOverlays.add(`${g.type} ${l.from}<>${l.to}`);
+  }
+  prevAssets.overlayLinks = diffAndLog("overlay-link", prevAssets.overlayLinks, currOverlays);
 
   // Build ARP-based connections (non-blocking, runs in background)
   pollArpLinks(devices, allIps).catch(e => console.warn("[poller] ARP poll failed:", e));
@@ -263,6 +330,12 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   cache.set("arpLinks", arpLinks, TTL.PORTS);
   cache.set("arpDevices", arpDevices, TTL.PORTS);
   console.log(`[poller] Cached ${arpLinks.length} ARP links, ${arpDevices.length} discovered devices (consolidated) from ${allArpEntries.length} ARP entries`);
+
+  const currArpDevices = new Set(arpDevices.map(d => {
+    const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
+    return `${mac} at ${d.location}`;
+  }));
+  prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
 }
 
 function consolidateArpDevices(
@@ -430,6 +503,7 @@ export async function pollRoutes() {
 
   let totalRoutes = 0;
   let devicesWithRoutes = 0;
+  const currRoutes = new Set<string>();
 
   for (const device of devices) {
     if (device.status !== 1) continue;
@@ -459,6 +533,7 @@ export async function pollRoutes() {
         cache.set(`routes:${device.hostname}`, routes, TTL.ROUTES);
         totalRoutes += routes.length;
         devicesWithRoutes++;
+        for (const r of routes) currRoutes.add(`${device.hostname} ${r.dest}/${r.prefix} via ${r.nextHop}`);
       }
     } catch {
       // skip devices that fail
@@ -467,6 +542,8 @@ export async function pollRoutes() {
   }
 
   console.log(`[poller] Cached ${totalRoutes} routes across ${devicesWithRoutes} devices`);
+
+  prevAssets.routes = diffAndLog("route", prevAssets.routes, currRoutes);
 }
 
 export async function pollAlerts() {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,14 +1,31 @@
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import { cache } from "../cache/store.js";
+import { subscribeEvents, unsubscribeEvents } from "../jobs/poller.js";
 import type { AssetEvent } from "@librenms-dash/shared";
 
 const app = new Hono();
 
-app.get("/", (c) => {
-  const since = Number(c.req.query("since") ?? 0);
-  const events = cache.get<AssetEvent[]>("assetEvents") ?? [];
-  const filtered = since > 0 ? events.filter(e => e.id > since) : events;
-  return c.json({ events: filtered });
+app.get("/stream", (c) => {
+  return streamSSE(c, async (stream) => {
+    const backlog = cache.get<AssetEvent[]>("assetEvents") ?? [];
+    if (backlog.length > 0) {
+      await stream.writeSSE({ data: JSON.stringify(backlog), event: "init" });
+    }
+
+    const onEvents = (events: AssetEvent[]) => {
+      stream.writeSSE({ data: JSON.stringify(events), event: "events" }).catch(() => {});
+    };
+
+    subscribeEvents(onEvents);
+    stream.onAbort(() => unsubscribeEvents(onEvents));
+
+    // Keep alive — Hono closes the stream when this function returns,
+    // so we block until the client disconnects.
+    while (!stream.aborted) {
+      await stream.sleep(30_000);
+    }
+  });
 });
 
 export default app;

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+import { cache } from "../cache/store.js";
+import type { AssetEvent } from "@librenms-dash/shared";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  const since = Number(c.req.query("since") ?? 0);
+  const events = cache.get<AssetEvent[]>("assetEvents") ?? [];
+  const filtered = since > 0 ? events.filter(e => e.id > since) : events;
+  return c.json({ events: filtered });
+});
+
+export default app;

--- a/frontend/src/components/AssetEventToast.tsx
+++ b/frontend/src/components/AssetEventToast.tsx
@@ -127,12 +127,25 @@ export function AssetEventToast() {
     });
   }, []);
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!panelOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setPanelOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [panelOpen]);
+
   // Pagination
   const reversed = useMemo(() => [...allEvents].reverse(), [allEvents]);
   const totalPages = Math.max(1, Math.ceil(reversed.length / PAGE_SIZE));
   const pageEvents = useMemo(() => reversed.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE), [reversed, page]);
 
   const lastEvent = allEvents.length > 0 ? allEvents[allEvents.length - 1] : null;
+  const recentEvent = lastEvent && (Date.now() - new Date(lastEvent.timestamp).getTime() < 5 * 60 * 1000) ? lastEvent : null;
 
   return (
     <>
@@ -164,7 +177,7 @@ export function AssetEventToast() {
       )}
 
       {/* Bar + panel wrapper — single column anchored at bottom-right */}
-      <div className="absolute bottom-7 right-2 z-20 flex flex-col items-end">
+      <div ref={wrapperRef} className="absolute bottom-7 right-2 z-20 flex flex-col items-end">
         {/* Expanded event log panel — grows upward from bar */}
         <div
           className={`w-[500px] transition-all duration-300 ease-out origin-bottom overflow-hidden ${
@@ -240,10 +253,10 @@ export function AssetEventToast() {
         >
           <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${connected ? "bg-emerald-500" : "bg-gray-600"}`} />
           <span className="text-gray-400">
-            {allEvents.length === 0
-              ? "No events"
-              : lastEvent
-                ? <><span className="capitalize">{lastEvent.category}</span> <span className={eventColor(lastEvent.action)}>{lastEvent.action}</span></>
+            {recentEvent
+              ? <><span className="capitalize">{recentEvent.category}</span> <span className={eventColor(recentEvent.action)}>{recentEvent.action}</span></>
+              : allEvents.length === 0
+                ? "No events"
                 : `${allEvents.length} events`
             }
           </span>

--- a/frontend/src/components/AssetEventToast.tsx
+++ b/frontend/src/components/AssetEventToast.tsx
@@ -1,18 +1,17 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { AssetEvent } from "@librenms-dash/shared";
-import { fetchEvents } from "@/lib/api";
 
-const POLL_MS = 30_000;
 const TOAST_DURATION_MS = 5_000;
 const TOAST_GAP_MS = 1_500;
 const MAX_QUEUE = 5;
-
-function eventIcon(action: string) {
-  return action === "added" ? "+" : "-";
-}
+const PAGE_SIZE = 25;
 
 function eventColor(action: string) {
   return action === "added" ? "text-emerald-400" : "text-red-400";
+}
+
+function eventBg(action: string) {
+  return action === "added" ? "bg-emerald-500" : "bg-red-500";
 }
 
 function formatTs(iso: string) {
@@ -27,12 +26,13 @@ export function AssetEventToast() {
   const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
   const [queue, setQueue] = useState<AssetEvent[]>([]);
   const [toast, setToast] = useState<AssetEvent | null>(null);
-  const [visible, setVisible] = useState(false);
-  const [logOpen, setLogOpen] = useState(false);
-  const hovered = useRef(false);
-  const lastSeenId = useRef(0);
+  const [toastVisible, setToastVisible] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [newCount, setNewCount] = useState(0);
+  const [connected, setConnected] = useState(false);
+  const toastHovered = useRef(false);
   const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const gapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inGap = useRef(false);
 
   const clearDismiss = useCallback(() => {
@@ -41,101 +41,114 @@ export function AssetEventToast() {
 
   const dismissToast = useCallback(() => {
     clearDismiss();
-    setVisible(false);
+    setToastVisible(false);
     setTimeout(() => {
       setToast(null);
       inGap.current = true;
-      gapTimer.current = setTimeout(() => { inGap.current = false; }, TOAST_GAP_MS);
+      setTimeout(() => { inGap.current = false; }, TOAST_GAP_MS);
     }, 300);
   }, [clearDismiss]);
 
-  // Poll backend for new events
-  useEffect(() => {
-    let mounted = true;
-    const poll = async () => {
-      try {
-        const { events } = await fetchEvents(lastSeenId.current);
-        if (!mounted || events.length === 0) return;
-        lastSeenId.current = events[events.length - 1].id;
-        setAllEvents(prev => [...prev, ...events].slice(-200));
-        setQueue(prev => {
-          const merged = [...prev, ...events];
-          if (merged.length > MAX_QUEUE) {
-            return merged.slice(-MAX_QUEUE);
-          }
-          return merged;
-        });
-      } catch { /* ignore fetch errors */ }
-    };
-    poll();
-    const id = setInterval(poll, POLL_MS);
-    return () => { mounted = false; clearInterval(id); };
+  const addEvents = useCallback((events: AssetEvent[]) => {
+    setAllEvents(prev => [...prev, ...events].slice(-200));
+    setNewCount(prev => prev + events.length);
+    setQueue(prev => {
+      const merged = [...prev, ...events];
+      return merged.length > MAX_QUEUE ? merged.slice(-MAX_QUEUE) : merged;
+    });
   }, []);
+
+  // SSE connection
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+    es.addEventListener("init", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) setAllEvents(events);
+      } catch { /* ignore */ }
+    });
+    es.addEventListener("events", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) addEvents(events);
+      } catch { /* ignore */ }
+    });
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    return () => { es.close(); setConnected(false); };
+  }, [addEvents]);
 
   // Show next toast from queue
   useEffect(() => {
-    if (toast || queue.length === 0 || inGap.current) return;
+    if (toast || queue.length === 0 || inGap.current || panelOpen) return;
     const next = queue[0];
     setQueue(prev => prev.slice(1));
     setToast(next);
-    setVisible(true);
-  }, [toast, queue]);
+    setToastVisible(true);
+  }, [toast, queue, panelOpen]);
 
-  // Auto-dismiss timer — restarts when toast changes or hover state changes
+  // Auto-dismiss
   useEffect(() => {
-    if (!toast || !visible) return;
-    if (hovered.current) return;
+    if (!toast || !toastVisible) return;
+    if (toastHovered.current) return;
     clearDismiss();
     dismissTimer.current = setTimeout(dismissToast, TOAST_DURATION_MS);
     return clearDismiss;
-  }, [toast, visible, dismissToast, clearDismiss]);
+  }, [toast, toastVisible, dismissToast, clearDismiss]);
 
-  // Retry showing next toast after gap
+  // Drain queue after gap
   useEffect(() => {
     if (toast || queue.length === 0) return;
     const id = setInterval(() => {
-      if (!inGap.current) {
-        clearInterval(id);
-        setQueue(prev => [...prev]);
-      }
+      if (!inGap.current) { clearInterval(id); setQueue(prev => [...prev]); }
     }, 200);
     return () => clearInterval(id);
   }, [toast, queue]);
 
-  const handleMouseEnter = useCallback(() => {
-    hovered.current = true;
-    clearDismiss();
-  }, [clearDismiss]);
-
-  const handleMouseLeave = useCallback(() => {
-    hovered.current = false;
-    if (toast && visible) {
-      dismissTimer.current = setTimeout(dismissToast, TOAST_DURATION_MS);
-    }
-  }, [toast, visible, dismissToast]);
+  const handleToastEnter = useCallback(() => { toastHovered.current = true; clearDismiss(); }, [clearDismiss]);
+  const handleToastLeave = useCallback(() => {
+    toastHovered.current = false;
+    if (toast && toastVisible) dismissTimer.current = setTimeout(dismissToast, TOAST_DURATION_MS);
+  }, [toast, toastVisible, dismissToast]);
 
   const handleToastClick = useCallback(() => {
     clearDismiss();
-    setVisible(false);
+    setToastVisible(false);
     setTimeout(() => setToast(null), 300);
-    setLogOpen(true);
+    setPanelOpen(true);
+    setNewCount(0);
+    setPage(0);
   }, [clearDismiss]);
+
+  const togglePanel = useCallback(() => {
+    setPanelOpen(prev => {
+      if (!prev) { setNewCount(0); setPage(0); }
+      return !prev;
+    });
+  }, []);
+
+  // Pagination
+  const reversed = useMemo(() => [...allEvents].reverse(), [allEvents]);
+  const totalPages = Math.max(1, Math.ceil(reversed.length / PAGE_SIZE));
+  const pageEvents = useMemo(() => reversed.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE), [reversed, page]);
+
+  const lastEvent = allEvents.length > 0 ? allEvents[allEvents.length - 1] : null;
 
   return (
     <>
-      {/* Toast */}
+      {/* Toast — slides in above the bar */}
       {toast && (
         <div
-          className={`absolute bottom-8 right-2 z-20 max-w-[340px] cursor-pointer transition-all duration-300 ease-out ${
-            visible ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
+          className={`absolute bottom-14 right-2 z-30 max-w-[340px] cursor-pointer transition-all duration-300 ease-out ${
+            toastVisible ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
           }`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onMouseEnter={handleToastEnter}
+          onMouseLeave={handleToastLeave}
           onClick={handleToastClick}
         >
           <div className="bg-gray-900/95 backdrop-blur border border-gray-700 rounded-lg px-3 py-2 shadow-lg flex items-start gap-2">
             <span className={`font-mono font-bold text-sm leading-none mt-0.5 ${eventColor(toast.action)}`}>
-              {eventIcon(toast.action)}
+              {toast.action === "added" ? "+" : "−"}
             </span>
             <div className="min-w-0">
               <div className="text-[11px] text-gray-300 leading-snug truncate">
@@ -150,60 +163,100 @@ export function AssetEventToast() {
         </div>
       )}
 
-      {/* Event count badge — click to open log */}
-      {allEvents.length > 0 && !logOpen && (
-        <button
-          onClick={() => setLogOpen(true)}
-          className="absolute bottom-8 right-2 z-20 bg-gray-900/90 backdrop-blur border border-gray-700 rounded-full px-2 py-0.5 text-[10px] text-gray-400 hover:text-gray-200 transition-colors"
-          style={toast ? { display: "none" } : undefined}
-          title="Asset change log"
+      {/* Bar + panel wrapper — single column anchored at bottom-right */}
+      <div className="absolute bottom-7 right-2 z-20 flex flex-col items-end">
+        {/* Expanded event log panel — grows upward from bar */}
+        <div
+          className={`w-[500px] transition-all duration-300 ease-out origin-bottom overflow-hidden ${
+            panelOpen ? "max-h-[460px] opacity-100" : "max-h-0 opacity-0"
+          }`}
         >
-          {allEvents.length} event{allEvents.length !== 1 ? "s" : ""}
-        </button>
-      )}
-
-      {/* Full event log panel */}
-      {logOpen && (
-        <div className="absolute bottom-8 right-2 z-30 w-[460px] max-h-[420px] bg-gray-900/98 backdrop-blur border border-gray-700 rounded-lg shadow-2xl flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700">
-            <span className="text-xs font-semibold text-gray-300">Asset Change Log ({allEvents.length})</span>
-            <button
-              onClick={() => setLogOpen(false)}
-              className="text-gray-500 hover:text-gray-200 text-sm leading-none px-1"
-            >
-              &times;
-            </button>
-          </div>
-          <div className="overflow-y-auto flex-1 scrollbar-thin">
-            {allEvents.length === 0 ? (
-              <div className="p-4 text-center text-xs text-gray-500">No events yet</div>
-            ) : (
-              <table className="w-full text-[11px] border-collapse">
-                <thead className="sticky top-0 bg-gray-900">
-                  <tr>
-                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Time</th>
-                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Action</th>
-                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Category</th>
-                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Asset</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {[...allEvents].reverse().map((e) => (
-                    <tr key={e.id} className="border-t border-gray-800 hover:bg-gray-800/50">
-                      <td className="py-1 px-2 text-gray-500 whitespace-nowrap font-mono">{formatTs(e.timestamp)}</td>
-                      <td className={`py-1 px-2 whitespace-nowrap font-semibold ${eventColor(e.action)}`}>
-                        {e.action}
-                      </td>
-                      <td className="py-1 px-2 text-gray-400 whitespace-nowrap capitalize">{e.category}</td>
-                      <td className="py-1 px-2 text-gray-300 break-all max-w-[200px]" title={e.asset}>{e.asset}</td>
+          <div className="bg-gray-900/98 backdrop-blur border border-gray-700 border-b-0 rounded-t-lg shadow-2xl flex flex-col" style={{ height: 420 }}>
+            <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700 shrink-0">
+              <span className="text-xs font-semibold text-gray-300">
+                Asset Change Log
+                <span className="text-gray-500 ml-1.5 font-normal">{allEvents.length} total</span>
+              </span>
+              <button
+                onClick={() => setPanelOpen(false)}
+                className="text-gray-500 hover:text-gray-200 text-sm leading-none px-1"
+              >&times;</button>
+            </div>
+            <div className="overflow-y-auto flex-1">
+              {allEvents.length === 0 ? (
+                <div className="p-6 text-center text-xs text-gray-500">No events yet — changes will appear after the next poll cycle.</div>
+              ) : (
+                <table className="w-full text-[11px] border-collapse">
+                  <thead className="sticky top-0 bg-gray-900/95 backdrop-blur">
+                    <tr>
+                      <th className="py-1.5 px-2 text-left text-gray-500 font-semibold">Time</th>
+                      <th className="py-1.5 px-2 text-left text-gray-500 font-semibold w-16">Action</th>
+                      <th className="py-1.5 px-2 text-left text-gray-500 font-semibold">Category</th>
+                      <th className="py-1.5 px-2 text-left text-gray-500 font-semibold">Asset</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {pageEvents.map((e) => (
+                      <tr key={e.id} className="border-t border-gray-800/60 hover:bg-gray-800/40 transition-colors">
+                        <td className="py-1 px-2 text-gray-500 whitespace-nowrap font-mono">{formatTs(e.timestamp)}</td>
+                        <td className="py-1 px-2 whitespace-nowrap">
+                          <span className={`inline-flex items-center gap-1 ${eventColor(e.action)}`}>
+                            <span className={`w-1.5 h-1.5 rounded-full ${eventBg(e.action)}`} />
+                            {e.action}
+                          </span>
+                        </td>
+                        <td className="py-1 px-2 text-gray-400 whitespace-nowrap capitalize">{e.category}</td>
+                        <td className="py-1 px-2 text-gray-300 truncate max-w-[180px]" title={e.asset}>{e.asset}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between px-3 py-1.5 border-t border-gray-700 shrink-0 text-[10px] text-gray-400">
+                <button
+                  onClick={() => setPage(p => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-default transition-colors"
+                >Newer</button>
+                <span>Page {page + 1} / {totalPages}</span>
+                <button
+                  onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                  className="px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-default transition-colors"
+                >Older</button>
+              </div>
             )}
           </div>
         </div>
-      )}
+
+        {/* Persistent floating bar — always at the bottom of this wrapper */}
+        <button
+          onClick={togglePanel}
+          className={`flex items-center gap-2 bg-gray-900/90 backdrop-blur border border-gray-700 px-2.5 py-1 text-[10px] transition-all duration-200 hover:bg-gray-800/90 ${
+            panelOpen ? "w-[500px] rounded-b-lg rounded-t-none border-t-gray-800" : "rounded-lg"
+          }`}
+        >
+          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${connected ? "bg-emerald-500" : "bg-gray-600"}`} />
+          <span className="text-gray-400">
+            {allEvents.length === 0
+              ? "No events"
+              : lastEvent
+                ? <><span className="capitalize">{lastEvent.category}</span> <span className={eventColor(lastEvent.action)}>{lastEvent.action}</span></>
+                : `${allEvents.length} events`
+            }
+          </span>
+          {newCount > 0 && !panelOpen && (
+            <span className="bg-blue-600 text-white text-[9px] font-bold rounded-full px-1.5 py-0 leading-relaxed animate-pulse">
+              {newCount}
+            </span>
+          )}
+          <span className={`text-gray-600 text-[9px] ml-auto transition-transform duration-200 ${panelOpen ? "rotate-180" : ""}`}>
+            &#9650;
+          </span>
+        </button>
+      </div>
     </>
   );
 }

--- a/frontend/src/components/AssetEventToast.tsx
+++ b/frontend/src/components/AssetEventToast.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { AssetEvent } from "@librenms-dash/shared";
+import { fetchEvents } from "@/lib/api";
+
+const POLL_MS = 30_000;
+const TOAST_DURATION_MS = 5_000;
+const TOAST_GAP_MS = 1_500;
+const MAX_QUEUE = 5;
+
+function eventIcon(action: string) {
+  return action === "added" ? "+" : "-";
+}
+
+function eventColor(action: string) {
+  return action === "added" ? "text-emerald-400" : "text-red-400";
+}
+
+function formatTs(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short", day: "numeric",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+    hour12: false,
+  });
+}
+
+export function AssetEventToast() {
+  const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
+  const [queue, setQueue] = useState<AssetEvent[]>([]);
+  const [toast, setToast] = useState<AssetEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [logOpen, setLogOpen] = useState(false);
+  const hovered = useRef(false);
+  const lastSeenId = useRef(0);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inGap = useRef(false);
+
+  const clearDismiss = useCallback(() => {
+    if (dismissTimer.current) { clearTimeout(dismissTimer.current); dismissTimer.current = null; }
+  }, []);
+
+  const dismissToast = useCallback(() => {
+    clearDismiss();
+    setVisible(false);
+    setTimeout(() => {
+      setToast(null);
+      inGap.current = true;
+      gapTimer.current = setTimeout(() => { inGap.current = false; }, TOAST_GAP_MS);
+    }, 300);
+  }, [clearDismiss]);
+
+  // Poll backend for new events
+  useEffect(() => {
+    let mounted = true;
+    const poll = async () => {
+      try {
+        const { events } = await fetchEvents(lastSeenId.current);
+        if (!mounted || events.length === 0) return;
+        lastSeenId.current = events[events.length - 1].id;
+        setAllEvents(prev => [...prev, ...events].slice(-200));
+        setQueue(prev => {
+          const merged = [...prev, ...events];
+          if (merged.length > MAX_QUEUE) {
+            return merged.slice(-MAX_QUEUE);
+          }
+          return merged;
+        });
+      } catch { /* ignore fetch errors */ }
+    };
+    poll();
+    const id = setInterval(poll, POLL_MS);
+    return () => { mounted = false; clearInterval(id); };
+  }, []);
+
+  // Show next toast from queue
+  useEffect(() => {
+    if (toast || queue.length === 0 || inGap.current) return;
+    const next = queue[0];
+    setQueue(prev => prev.slice(1));
+    setToast(next);
+    setVisible(true);
+  }, [toast, queue]);
+
+  // Auto-dismiss timer — restarts when toast changes or hover state changes
+  useEffect(() => {
+    if (!toast || !visible) return;
+    if (hovered.current) return;
+    clearDismiss();
+    dismissTimer.current = setTimeout(dismissToast, TOAST_DURATION_MS);
+    return clearDismiss;
+  }, [toast, visible, dismissToast, clearDismiss]);
+
+  // Retry showing next toast after gap
+  useEffect(() => {
+    if (toast || queue.length === 0) return;
+    const id = setInterval(() => {
+      if (!inGap.current) {
+        clearInterval(id);
+        setQueue(prev => [...prev]);
+      }
+    }, 200);
+    return () => clearInterval(id);
+  }, [toast, queue]);
+
+  const handleMouseEnter = useCallback(() => {
+    hovered.current = true;
+    clearDismiss();
+  }, [clearDismiss]);
+
+  const handleMouseLeave = useCallback(() => {
+    hovered.current = false;
+    if (toast && visible) {
+      dismissTimer.current = setTimeout(dismissToast, TOAST_DURATION_MS);
+    }
+  }, [toast, visible, dismissToast]);
+
+  const handleToastClick = useCallback(() => {
+    clearDismiss();
+    setVisible(false);
+    setTimeout(() => setToast(null), 300);
+    setLogOpen(true);
+  }, [clearDismiss]);
+
+  return (
+    <>
+      {/* Toast */}
+      {toast && (
+        <div
+          className={`absolute bottom-8 right-2 z-20 max-w-[340px] cursor-pointer transition-all duration-300 ease-out ${
+            visible ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
+          }`}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onClick={handleToastClick}
+        >
+          <div className="bg-gray-900/95 backdrop-blur border border-gray-700 rounded-lg px-3 py-2 shadow-lg flex items-start gap-2">
+            <span className={`font-mono font-bold text-sm leading-none mt-0.5 ${eventColor(toast.action)}`}>
+              {eventIcon(toast.action)}
+            </span>
+            <div className="min-w-0">
+              <div className="text-[11px] text-gray-300 leading-snug truncate">
+                <span className="text-gray-500 capitalize">{toast.category}</span>{" "}
+                <span className={eventColor(toast.action)}>{toast.action}</span>
+              </div>
+              <div className="text-[11px] text-gray-400 leading-snug truncate" title={toast.asset}>
+                {toast.asset}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Event count badge — click to open log */}
+      {allEvents.length > 0 && !logOpen && (
+        <button
+          onClick={() => setLogOpen(true)}
+          className="absolute bottom-8 right-2 z-20 bg-gray-900/90 backdrop-blur border border-gray-700 rounded-full px-2 py-0.5 text-[10px] text-gray-400 hover:text-gray-200 transition-colors"
+          style={toast ? { display: "none" } : undefined}
+          title="Asset change log"
+        >
+          {allEvents.length} event{allEvents.length !== 1 ? "s" : ""}
+        </button>
+      )}
+
+      {/* Full event log panel */}
+      {logOpen && (
+        <div className="absolute bottom-8 right-2 z-30 w-[460px] max-h-[420px] bg-gray-900/98 backdrop-blur border border-gray-700 rounded-lg shadow-2xl flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700">
+            <span className="text-xs font-semibold text-gray-300">Asset Change Log ({allEvents.length})</span>
+            <button
+              onClick={() => setLogOpen(false)}
+              className="text-gray-500 hover:text-gray-200 text-sm leading-none px-1"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="overflow-y-auto flex-1 scrollbar-thin">
+            {allEvents.length === 0 ? (
+              <div className="p-4 text-center text-xs text-gray-500">No events yet</div>
+            ) : (
+              <table className="w-full text-[11px] border-collapse">
+                <thead className="sticky top-0 bg-gray-900">
+                  <tr>
+                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Time</th>
+                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Action</th>
+                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Category</th>
+                    <th className="py-1 px-2 text-left text-gray-500 font-semibold">Asset</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...allEvents].reverse().map((e) => (
+                    <tr key={e.id} className="border-t border-gray-800 hover:bg-gray-800/50">
+                      <td className="py-1 px-2 text-gray-500 whitespace-nowrap font-mono">{formatTs(e.timestamp)}</td>
+                      <td className={`py-1 px-2 whitespace-nowrap font-semibold ${eventColor(e.action)}`}>
+                        {e.action}
+                      </td>
+                      <td className="py-1 px-2 text-gray-400 whitespace-nowrap capitalize">{e.category}</td>
+                      <td className="py-1 px-2 text-gray-300 break-all max-w-[200px]" title={e.asset}>{e.asset}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -13,6 +13,7 @@ import { DevicePopover } from "./DevicePopover";
 import { LinkTooltip, type LinkTooltipData } from "./LinkTooltip";
 import { curvedLinkPath, pointToPointPath, computeDominantSide, DEVICE_HALF, ARP_HALF, type Side } from "@/lib/linkGeometry";
 import { Logo } from "./Logo";
+import { AssetEventToast } from "./AssetEventToast";
 
 interface Props {
   data: TopologyResponse;
@@ -1186,6 +1187,9 @@ export function TopologyMap({ data }: Props) {
       <div className="absolute top-4 right-4 z-10 pointer-events-none">
         <Logo size={48} />
       </div>
+
+      {/* Asset change toasts — above copyright bar */}
+      <AssetEventToast />
 
       {/* Bottom-right: GPLv3 copyright, GitHub link, commit SHA */}
       <div className="absolute bottom-2 right-2 z-10 pointer-events-auto flex items-center gap-2 text-[10px] text-gray-500">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { TopologyResponse, DeviceOverview, AssetEvent } from "@librenms-dash/shared";
+import type { TopologyResponse, DeviceOverview } from "@librenms-dash/shared";
 
 const BASE = "/api";
 
@@ -24,10 +24,6 @@ export function graphUrl(hostname: string, type: string, opts?: { from?: string;
     height: String(opts?.height ?? 150),
   });
   return `${BASE}/graph/device/${hostname}/${type}?${params}`;
-}
-
-export function fetchEvents(since: number): Promise<{ events: AssetEvent[] }> {
-  return get(`/events?since=${since}`);
 }
 
 export function iconUrl(icon: string): string {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { TopologyResponse, DeviceOverview } from "@librenms-dash/shared";
+import type { TopologyResponse, DeviceOverview, AssetEvent } from "@librenms-dash/shared";
 
 const BASE = "/api";
 
@@ -24,6 +24,10 @@ export function graphUrl(hostname: string, type: string, opts?: { from?: string;
     height: String(opts?.height ?? 150),
   });
   return `${BASE}/graph/device/${hostname}/${type}?${params}`;
+}
+
+export function fetchEvents(since: number): Promise<{ events: AssetEvent[] }> {
+  return get(`/events?since=${since}`);
 }
 
 export function iconUrl(icon: string): string {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,3 +171,11 @@ export interface DeviceOverview {
   alerts: Alert[];
   routes: DeviceRoute[];
 }
+
+export interface AssetEvent {
+  id: number;
+  timestamp: string;
+  action: "added" | "removed";
+  category: string;
+  asset: string;
+}


### PR DESCRIPTION
## Summary
- Track additions/removals of devices, ports, IPs, overlay links, discovered devices, and routes across poll cycles with timestamped logging
- Stream events to the frontend via Server-Sent Events (Hono `streamSSE`) instead of polling
- Persistent status bar (bottom-right) shows connection indicator and latest event (hidden if older than 5 min)
- Toast notifications slide in with rate limiting (5s display, 1.5s gap, max 5 queued), hover pauses dismiss
- Click bar or toast to open a scrollable, paginated event table; click outside to dismiss

## Test plan
- [ ] Verify events appear in backend logs after second poll cycle
- [ ] Confirm SSE stream connects (green dot in status bar)
- [ ] Test toast notifications appear and auto-dismiss
- [ ] Test hover-to-pause on toasts
- [ ] Test click-to-expand event panel with pagination
- [ ] Test click-outside-to-close panel behavior
- [ ] Verify bar falls back to event count after 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)