### PR TITLE
Fix/link no fly zone

### DIFF
--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -688,7 +688,7 @@ export function TopologyMap({ data }: Props) {
           (items-stretch) and never overlapping (justify-between; outer flex-wrap
           drops the right bar below the left on very narrow screens). The wrapper
           is pointer-transparent so panning still works in the gap between bars. */}
-      <div ref={topBarRef} className="absolute top-0 inset-x-0 z-10 p-4 flex flex-wrap items-stretch justify-between gap-3 pointer-events-none">
+      <div ref={topBarRef} className="absolute top-0 inset-x-0 z-10 p-4 flex flex-wrap items-stretch justify-between gap-3 pointer-events-none max-w-[calc(100%-72px)]">
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-3 bg-gray-900/90 backdrop-blur border border-gray-700 rounded-lg px-4 py-2 pointer-events-auto">
         <button
@@ -740,10 +740,16 @@ export function TopologyMap({ data }: Props) {
               }`}
             >
               <span
-                className="w-3 h-0.5 inline-block rounded"
+                className="w-3 h-0.5 inline-block rounded self-center"
                 style={{ backgroundColor: color, opacity: visible ? 1 : 0.3 }}
               />
-              {o.label} ({o.links.length}){o.hub ? " ⭐" : ""}
+              <span className="flex flex-col leading-tight">
+                <span>{o.label.replace(/\s*\(.*\)\s*$/, "")} ({o.links.length}){o.hub ? " ⭐" : ""}</span>
+                <span
+                  className="text-[9px] font-mono opacity-70"
+                  style={{ color: visible ? color : undefined }}
+                >{o.subnet}</span>
+              </span>
             </button>
           );
         })}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -25,6 +25,11 @@ const LINK_HOVER_DELAY = 1000;
 
 const NEIGHBOR_COLOR = "#38bdf8";
 const ARP_COLOR = "#fbbf24";
+const OVERLAY_PALETTE = [
+  "#a78bfa", "#f472b6", "#34d399", "#fbbf24",
+  "#60a5fa", "#fb923c", "#2dd4bf", "#c084fc",
+  "#f87171", "#4ade80", "#38bdf8", "#e879f9",
+];
 
 function snapValue(value: number): number {
   return Math.round(value / GRID_SIZE) * GRID_SIZE;
@@ -217,7 +222,24 @@ export function TopologyMap({ data }: Props) {
     return map;
   }, [nodes]);
 
-  const visibleLinks = links.filter((l) => !hiddenOverlays[l.overlayType]);
+  const overlayColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (let i = 0; i < (data?.overlays ?? []).length; i++) {
+      const o = data!.overlays[i];
+      map.set(`${o.overlayType}:${o.subnet}`, OVERLAY_PALETTE[i % OVERLAY_PALETTE.length]);
+    }
+    return map;
+  }, [data]);
+
+  const visibleLinks = useMemo(() =>
+    links
+      .filter((l) => !hiddenOverlays[l.overlayKey])
+      .map((l) => {
+        const c = overlayColorMap.get(l.overlayKey);
+        return c && c !== l.color ? { ...l, color: c } : l;
+      }),
+    [links, hiddenOverlays, overlayColorMap],
+  );
 
   // Pre-compute a single anchor side per device based on all its visible peers.
   const deviceSide = useMemo(() => {
@@ -705,19 +727,21 @@ export function TopologyMap({ data }: Props) {
         </span>
         <span className="text-gray-600">|</span>
         <span className="text-xs text-gray-400 font-semibold mr-2">Overlays:</span>
-        {data.overlays.map((o) => {
-          const visible = !hiddenOverlays[o.overlayType];
+        {data.overlays.map((o, i) => {
+          const key = `${o.overlayType}:${o.subnet}`;
+          const color = OVERLAY_PALETTE[i % OVERLAY_PALETTE.length];
+          const visible = !hiddenOverlays[key];
           return (
             <button
-              key={`${o.overlayType}:${o.subnet}`}
-              onClick={() => toggleOverlay(o.overlayType)}
+              key={key}
+              onClick={() => toggleOverlay(key)}
               className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ${
                 visible ? "bg-gray-700 text-white" : "bg-gray-800 text-gray-500"
               }`}
             >
               <span
                 className="w-3 h-0.5 inline-block rounded"
-                style={{ backgroundColor: o.color, opacity: visible ? 1 : 0.3 }}
+                style={{ backgroundColor: color, opacity: visible ? 1 : 0.3 }}
               />
               {o.label} ({o.links.length}){o.hub ? " ⭐" : ""}
             </button>

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -17,6 +17,7 @@ export interface LayoutLink {
   source: LayoutNode;
   target: LayoutNode;
   overlayType: string;
+  overlayKey: string;
   color: string;
   fromIp: string;
   toIp: string;
@@ -354,6 +355,7 @@ function layoutAll(
           source: src,
           target: tgt,
           overlayType: overlay.overlayType,
+          overlayKey: `${overlay.overlayType}:${overlay.subnet}`,
           color: overlay.color,
           fromIp: link.fromIp,
           toIp: link.toIp,

--- a/frontend/src/lib/linkGeometry.ts
+++ b/frontend/src/lib/linkGeometry.ts
@@ -24,6 +24,15 @@ export function anchorPointForSide(
   }
 }
 
+function sideNormal(side: Side): { x: number; y: number } {
+  switch (side) {
+    case "left": return { x: -1, y: 0 };
+    case "right": return { x: 1, y: 0 };
+    case "top": return { x: 0, y: -1 };
+    case "bottom": return { x: 0, y: 1 };
+  }
+}
+
 /**
  * Given a device center and all its peer centers, pick the single side
  * that faces the most peers. Ties broken by: right > bottom > left > top.
@@ -55,6 +64,47 @@ export function computeDominantSide(
   return best;
 }
 
+function computeControlPointOffset(
+  anchor: { x: number; y: number },
+  target: { x: number; y: number },
+  side: Side,
+  half: HalfDims,
+): number {
+  const n = sideNormal(side);
+  const toTarget = { x: target.x - anchor.x, y: target.y - anchor.y };
+  const dot = toTarget.x * n.x + toTarget.y * n.y;
+  const dist = Math.sqrt(toTarget.x * toTarget.x + toTarget.y * toTarget.y) || 1;
+  // dot < 0 means the target is behind the exit direction (opposite side)
+  // Scale offset: minimum clearance of the box dimension, more for opposite-side targets
+  const minOffset = Math.max(half.halfW, half.halfH) + 20;
+  if (dot >= 0) {
+    return Math.max(minOffset, dist * 0.35);
+  }
+  // Target is behind — need a wide swing to clear the box
+  return Math.max(minOffset * 1.5, dist * 0.5);
+}
+
+function cubicPath(
+  sx: number, sy: number,
+  tx: number, ty: number,
+  sSide: Side,
+  tSide: Side,
+  sHalf: HalfDims,
+  tHalf: HalfDims,
+): string {
+  const s = anchorPointForSide(sx, sy, sSide, sHalf);
+  const t = anchorPointForSide(tx, ty, tSide, tHalf);
+  const sn = sideNormal(sSide);
+  const tn = sideNormal(tSide);
+  const sOff = computeControlPointOffset(s, t, sSide, sHalf);
+  const tOff = computeControlPointOffset(t, s, tSide, tHalf);
+  const cp1x = s.x + sn.x * sOff;
+  const cp1y = s.y + sn.y * sOff;
+  const cp2x = t.x + tn.x * tOff;
+  const cp2y = t.y + tn.y * tOff;
+  return `M ${s.x} ${s.y} C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${t.x} ${t.y}`;
+}
+
 export function pointToPointPath(
   ax: number, ay: number,
   bx: number, by: number,
@@ -63,23 +113,9 @@ export function pointToPointPath(
   sourceHalf: HalfDims = DEVICE_HALF,
   targetHalf: HalfDims = ARP_HALF,
 ): string {
-  const a = sourceSide
-    ? anchorPointForSide(ax, ay, sourceSide, sourceHalf)
-    : anchorPointForSide(ax, ay, computeDominantSide(ax, ay, [{ x: bx, y: by }], sourceHalf), sourceHalf);
-  const b = targetSide
-    ? anchorPointForSide(bx, by, targetSide, targetHalf)
-    : anchorPointForSide(bx, by, computeDominantSide(bx, by, [{ x: ax, y: ay }], targetHalf), targetHalf);
-  const dx = b.x - a.x;
-  const dy = b.y - a.y;
-  const dist = Math.sqrt(dx * dx + dy * dy);
-  const curvature = Math.min(dist * 0.25, 60);
-  const mx = (a.x + b.x) / 2;
-  const my = (a.y + b.y) / 2;
-  const nx = -dy / (dist || 1);
-  const ny = dx / (dist || 1);
-  const cx = mx + nx * curvature;
-  const cy = my + ny * curvature;
-  return `M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}`;
+  const sSide = sourceSide ?? computeDominantSide(ax, ay, [{ x: bx, y: by }], sourceHalf);
+  const tSide = targetSide ?? computeDominantSide(bx, by, [{ x: ax, y: ay }], targetHalf);
+  return cubicPath(ax, ay, bx, by, sSide, tSide, sourceHalf, targetHalf);
 }
 
 export function curvedLinkPath(
@@ -90,25 +126,7 @@ export function curvedLinkPath(
   sourceHalf: HalfDims = DEVICE_HALF,
   targetHalf: HalfDims = DEVICE_HALF,
 ): string {
-  const s = sourceSide
-    ? anchorPointForSide(sx, sy, sourceSide, sourceHalf)
-    : anchorPointForSide(sx, sy, computeDominantSide(sx, sy, [{ x: tx, y: ty }], sourceHalf), sourceHalf);
-  const t = targetSide
-    ? anchorPointForSide(tx, ty, targetSide, targetHalf)
-    : anchorPointForSide(tx, ty, computeDominantSide(tx, ty, [{ x: sx, y: sy }], targetHalf), targetHalf);
-  const dx = t.x - s.x;
-  const dy = t.y - s.y;
-  const dist = Math.sqrt(dx * dx + dy * dy);
-  const curvature = Math.min(dist * 0.25, 60);
-
-  const mx = (s.x + t.x) / 2;
-  const my = (s.y + t.y) / 2;
-
-  const nx = -dy / (dist || 1);
-  const ny = dx / (dist || 1);
-
-  const cx1 = mx + nx * curvature;
-  const cy1 = my + ny * curvature;
-
-  return `M ${s.x} ${s.y} Q ${cx1} ${cy1} ${t.x} ${t.y}`;
+  const sSide = sourceSide ?? computeDominantSide(sx, sy, [{ x: tx, y: ty }], sourceHalf);
+  const tSide = targetSide ?? computeDominantSide(tx, ty, [{ x: sx, y: sy }], targetHalf);
+  return cubicPath(sx, sy, tx, ty, sSide, tSide, sourceHalf, targetHalf);
 }


### PR DESCRIPTION
The problem: deviceSide pre-computes a single anchor side per device based on ALL peers. If a device's peers are mostly to the right, every link — even one going left — exits from the right side, causing links to curve back through/under the device box.

What changed: Both curvedLinkPath and pointToPointPath now emit cubic Bezier paths (C command with two control points) instead of quadratic (Q with one). Each control point extends outward along the exit-side normal of its device box, so the curve always leaves the box going away from it. The offset distance scales up when the target is behind the exit direction, producing a wider arc that swings clear of the box.