### PR TITLE
feat: SSE-triggered topology refresh

### DIFF
--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -47,6 +47,20 @@ const sseListeners = new Set<EventListener>();
 export function subscribeEvents(fn: EventListener) { sseListeners.add(fn); }
 export function unsubscribeEvents(fn: EventListener) { sseListeners.delete(fn); }
 
+type TopologyListener = () => void;
+const topologyListeners = new Set<TopologyListener>();
+
+export function subscribeTopologyChanged(fn: TopologyListener) { topologyListeners.add(fn); }
+export function unsubscribeTopologyChanged(fn: TopologyListener) { topologyListeners.delete(fn); }
+
+let topologyChangedInCycle = false;
+
+function flushTopologyChanged() {
+  if (!topologyChangedInCycle) return;
+  topologyChangedInCycle = false;
+  for (const fn of topologyListeners) fn();
+}
+
 function pushEvents(events: AssetEvent[]) {
   if (events.length === 0) return;
   const existing = cache.get<AssetEvent[]>("assetEvents") ?? [];
@@ -71,6 +85,7 @@ function diffAndLog(category: string, prev: Set<string>, curr: Set<string>): Set
       }
     }
     pushEvents(events);
+    if (events.length > 0) topologyChangedInCycle = true;
   }
   assetBaseline.add(category);
   return curr;
@@ -122,6 +137,7 @@ export async function pollDevicesAndLocations() {
 
   const currDevices = new Set(devices.map(d => `${d.hostname} (${d.ip})`));
   prevAssets.devices = diffAndLog("device", prevAssets.devices, currDevices);
+  flushTopologyChanged();
 }
 
 export async function pollPortsAndIps() {
@@ -169,6 +185,7 @@ export async function pollPortsAndIps() {
     for (const l of g.links) currOverlays.add(`${g.overlayType} ${l.from}<>${l.to}`);
   }
   prevAssets.overlayLinks = diffAndLog("overlay-link", prevAssets.overlayLinks, currOverlays);
+  flushTopologyChanged();
 
   // Build ARP-based connections (non-blocking, runs in background)
   pollArpLinks(devices, allIps).catch(e => console.warn("[poller] ARP poll failed:", e));
@@ -343,6 +360,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
     return `${mac} at ${d.location}`;
   }));
   prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
+  flushTopologyChanged();
 }
 
 function consolidateArpDevices(
@@ -551,6 +569,7 @@ export async function pollRoutes() {
   console.log(`[poller] Cached ${totalRoutes} routes across ${devicesWithRoutes} devices`);
 
   prevAssets.routes = diffAndLog("route", prevAssets.routes, currRoutes);
+  flushTopologyChanged();
 }
 
 export async function pollAlerts() {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cache } from "../cache/store.js";
-import { subscribeEvents, unsubscribeEvents } from "../jobs/poller.js";
+import { subscribeEvents, unsubscribeEvents, subscribeTopologyChanged, unsubscribeTopologyChanged } from "../jobs/poller.js";
 import type { AssetEvent } from "@librenms-dash/shared";
 
 const app = new Hono();
@@ -18,7 +18,16 @@ app.get("/stream", (c) => {
     };
 
     subscribeEvents(onEvents);
-    stream.onAbort(() => unsubscribeEvents(onEvents));
+
+    const onTopologyChanged = () => {
+      stream.writeSSE({ data: JSON.stringify({ ts: new Date().toISOString() }), event: "topology-changed" }).catch(() => {});
+    };
+
+    subscribeTopologyChanged(onTopologyChanged);
+    stream.onAbort(() => {
+      unsubscribeEvents(onEvents);
+      unsubscribeTopologyChanged(onTopologyChanged);
+    });
 
     // Keep alive — Hono closes the stream when this function returns,
     // so we block until the client disconnects.

--- a/docs/superpowers/plans/2026-06-15-sse-topology-refresh.md
+++ b/docs/superpowers/plans/2026-06-15-sse-topology-refresh.md
@@ -1,0 +1,670 @@
+# SSE-Triggered Topology Refresh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the backend detects topology changes, push a signal over the existing SSE stream so the frontend re-fetches and updates the map immediately — no browser refresh required.
+
+**Architecture:** Add a `topology-changed` SSE event emitted by the backend poller when `diffAndLog` detects changes. Lift the frontend's EventSource out of `AssetEventToast` into a shared `useSSE` hook that both invalidates React Query's topology cache and feeds asset events to the toast component. Add a drag-deferral guard in `useForceLayout` so mid-drag updates don't snap positions.
+
+**Tech Stack:** Hono SSE streaming, React, @tanstack/react-query, TypeScript
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/jobs/poller.ts` | Modify | Add topology-changed listener set, flag in `diffAndLog`, flush at end of each poll function |
+| `backend/src/routes/events.ts` | Modify | Subscribe to topology-changed in SSE stream handler |
+| `frontend/src/hooks/useSSE.ts` | Create | Shared EventSource hook — asset events + topology invalidation |
+| `frontend/src/components/AssetEventToast.tsx` | Modify | Remove internal EventSource, accept asset events + connected via props |
+| `frontend/src/App.tsx` | Modify | Wire `useSSE` in Dashboard, pass props to `AssetEventToast` |
+| `frontend/src/components/TopologyMap.tsx` | Modify | Pass `isDragging` to `useForceLayout`, accept and forward `AssetEventToast` props |
+| `frontend/src/hooks/useForceLayout.ts` | Modify | Accept `isDragging` ref, defer layout recomputation during drag |
+
+---
+
+### Task 1: Backend — Topology-changed broadcast in poller
+
+**Files:**
+- Modify: `backend/src/jobs/poller.ts:44-77` (listener set and diffAndLog), `:112-125` (pollDevicesAndLocations), `:127-175` (pollPortsAndIps), `:505-554` (pollRoutes)
+
+- [ ] **Step 1: Add topology-changed listener infrastructure**
+
+After the existing `subscribeEvents`/`unsubscribeEvents` block (line 48), add the topology-changed equivalent. In `backend/src/jobs/poller.ts`, after line 48:
+
+```typescript
+type TopologyListener = () => void;
+const topologyListeners = new Set<TopologyListener>();
+
+export function subscribeTopologyChanged(fn: TopologyListener) { topologyListeners.add(fn); }
+export function unsubscribeTopologyChanged(fn: TopologyListener) { topologyListeners.delete(fn); }
+
+let topologyChangedInCycle = false;
+
+function flushTopologyChanged() {
+  if (!topologyChangedInCycle) return;
+  topologyChangedInCycle = false;
+  for (const fn of topologyListeners) fn();
+}
+```
+
+- [ ] **Step 2: Set flag in diffAndLog when changes are detected**
+
+In the `diffAndLog` function, after the `pushEvents(events)` call (line 73), add:
+
+```typescript
+    if (events.length > 0) topologyChangedInCycle = true;
+```
+
+The full block at lines 72-74 becomes:
+
+```typescript
+    pushEvents(events);
+    if (events.length > 0) topologyChangedInCycle = true;
+  }
+```
+
+- [ ] **Step 3: Flush at end of pollDevicesAndLocations**
+
+At the end of `pollDevicesAndLocations` (after line 124), add:
+
+```typescript
+  flushTopologyChanged();
+```
+
+- [ ] **Step 4: Flush at end of pollPortsAndIps**
+
+At the end of `pollPortsAndIps`, right before the `pollArpLinks` call (line 173), add:
+
+```typescript
+  flushTopologyChanged();
+```
+
+Note: `pollArpLinks` runs asynchronously in the background and calls `diffAndLog` for discovered-devices. After line 345 in `pollArpLinks` (after the `prevAssets.arpDevices = diffAndLog(...)` call), add:
+
+```typescript
+  flushTopologyChanged();
+```
+
+- [ ] **Step 5: Flush at end of pollRoutes**
+
+At the end of `pollRoutes`, after line 553 (`prevAssets.routes = diffAndLog(...)`), add:
+
+```typescript
+  flushTopologyChanged();
+```
+
+- [ ] **Step 6: Verify backend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p backend/tsconfig.json`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/jobs/poller.ts
+git commit -m "feat: add topology-changed broadcast to poller"
+```
+
+---
+
+### Task 2: Backend — Wire topology-changed into SSE stream
+
+**Files:**
+- Modify: `backend/src/routes/events.ts`
+
+- [ ] **Step 1: Import the new subscribe/unsubscribe functions**
+
+In `backend/src/routes/events.ts`, change line 4 from:
+
+```typescript
+import { subscribeEvents, unsubscribeEvents } from "../jobs/poller.js";
+```
+
+to:
+
+```typescript
+import { subscribeEvents, unsubscribeEvents, subscribeTopologyChanged, unsubscribeTopologyChanged } from "../jobs/poller.js";
+```
+
+- [ ] **Step 2: Add topology-changed listener in stream handler**
+
+Inside the `streamSSE` callback, after the `subscribeEvents(onEvents)` call (line 20) and before the `stream.onAbort` call (line 21), add:
+
+```typescript
+    const onTopologyChanged = () => {
+      stream.writeSSE({ data: JSON.stringify({ ts: new Date().toISOString() }), event: "topology-changed" }).catch(() => {});
+    };
+
+    subscribeTopologyChanged(onTopologyChanged);
+```
+
+- [ ] **Step 3: Unsubscribe on abort**
+
+Change the `stream.onAbort` line (line 21) from:
+
+```typescript
+    stream.onAbort(() => unsubscribeEvents(onEvents));
+```
+
+to:
+
+```typescript
+    stream.onAbort(() => {
+      unsubscribeEvents(onEvents);
+      unsubscribeTopologyChanged(onTopologyChanged);
+    });
+```
+
+- [ ] **Step 4: Verify backend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p backend/tsconfig.json`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/routes/events.ts
+git commit -m "feat: emit topology-changed SSE event on stream"
+```
+
+---
+
+### Task 3: Frontend — Create useSSE hook
+
+**Files:**
+- Create: `frontend/src/hooks/useSSE.ts`
+
+- [ ] **Step 1: Create the shared SSE hook**
+
+Create `frontend/src/hooks/useSSE.ts` with:
+
+```typescript
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { AssetEvent } from "@librenms-dash/shared";
+
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+  const addEventsRef = useRef<(events: AssetEvent[]) => void>();
+
+  const addEvents = useCallback((events: AssetEvent[]) => {
+    setAllEvents(prev => {
+      const merged = [...prev, ...events];
+      return merged.length > 200 ? merged.slice(-200) : merged;
+    });
+  }, []);
+
+  addEventsRef.current = addEvents;
+
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+
+    es.addEventListener("init", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) setAllEvents(events);
+      } catch { /* ignore */ }
+    });
+
+    es.addEventListener("events", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) addEventsRef.current?.(events);
+      } catch { /* ignore */ }
+    });
+
+    es.addEventListener("topology-changed", () => {
+      queryClient.invalidateQueries({ queryKey: ["topology"] });
+    });
+
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    return () => { es.close(); setConnected(false); };
+  }, [queryClient]);
+
+  return { allEvents, connected };
+}
+```
+
+- [ ] **Step 2: Verify frontend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p frontend/tsconfig.json`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/hooks/useSSE.ts
+git commit -m "feat: add shared useSSE hook with topology invalidation"
+```
+
+---
+
+### Task 4: Frontend — Refactor AssetEventToast to accept props
+
+**Files:**
+- Modify: `frontend/src/components/AssetEventToast.tsx`
+
+- [ ] **Step 1: Add props interface and update component signature**
+
+Change the component signature (line 25) from:
+
+```typescript
+export function AssetEventToast() {
+```
+
+to:
+
+```typescript
+interface AssetEventToastProps {
+  allEvents: AssetEvent[];
+  connected: boolean;
+}
+
+export function AssetEventToast({ allEvents, connected }: AssetEventToastProps) {
+```
+
+- [ ] **Step 2: Remove internal state that is now from props**
+
+Remove these lines from the component body (lines 26, 33):
+
+```typescript
+  const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
+```
+
+```typescript
+  const [connected, setConnected] = useState(false);
+```
+
+- [ ] **Step 3: Replace the addEvents callback with a prop-watching effect**
+
+Remove the `addEvents` callback (lines 52-59):
+
+```typescript
+  const addEvents = useCallback((events: AssetEvent[]) => {
+    setAllEvents(prev => [...prev, ...events].slice(-200));
+    setNewCount(prev => prev + events.length);
+    setQueue(prev => {
+      const merged = [...prev, ...events];
+      return merged.length > MAX_QUEUE ? merged.slice(-MAX_QUEUE) : merged;
+    });
+  }, []);
+```
+
+Replace it with a `useEffect` that watches the `allEvents` prop to update the toast queue and new count when new events arrive:
+
+```typescript
+  const prevLengthRef = useRef(allEvents.length);
+  useEffect(() => {
+    const prevLen = prevLengthRef.current;
+    prevLengthRef.current = allEvents.length;
+    if (allEvents.length <= prevLen) return;
+    const newEvents = allEvents.slice(prevLen);
+    if (newEvents.length === 0) return;
+    setNewCount(prev => prev + newEvents.length);
+    setQueue(prev => {
+      const merged = [...prev, ...newEvents];
+      return merged.length > MAX_QUEUE ? merged.slice(-MAX_QUEUE) : merged;
+    });
+  }, [allEvents]);
+```
+
+- [ ] **Step 4: Remove the SSE connection useEffect**
+
+Remove the entire SSE connection `useEffect` block (lines 61-79):
+
+```typescript
+  // SSE connection
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+    es.addEventListener("init", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) setAllEvents(events);
+      } catch { /* ignore */ }
+    });
+    es.addEventListener("events", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) addEvents(events);
+      } catch { /* ignore */ }
+    });
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    return () => { es.close(); setConnected(false); };
+  }, [addEvents]);
+```
+
+- [ ] **Step 5: Remove unused useState import usage**
+
+The component still uses `useState` for `queue`, `toast`, `toastVisible`, `panelOpen`, `page`, `newCount`. Verify the `useState` import is still present (it is — other state variables use it). Remove the now-unused `setAllEvents` references — there are none left after removing the SSE effect and addEvents callback.
+
+- [ ] **Step 6: Verify frontend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p frontend/tsconfig.json`
+Expected: Errors about `AssetEventToast` usage in `TopologyMap.tsx` missing required props — this is expected and will be fixed in Task 6.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/AssetEventToast.tsx
+git commit -m "refactor: AssetEventToast accepts events via props"
+```
+
+---
+
+### Task 5: Frontend — Wire useSSE in App.tsx and pass props through
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Import useSSE**
+
+Add to the imports in `App.tsx`:
+
+```typescript
+import { useSSE } from "@/hooks/useSSE";
+```
+
+- [ ] **Step 2: Call useSSE in Dashboard and pass props to TopologyMap**
+
+Change the `Dashboard` function from:
+
+```typescript
+function Dashboard() {
+  const { data, isLoading, error } = useTopology();
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-gray-950">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-gray-600 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-400 text-sm">Loading topology from LibreNMS...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-gray-950">
+        <div className="text-center max-w-md px-4">
+          <p className="text-red-400 text-lg font-semibold mb-2">Failed to load topology</p>
+          <p className="text-gray-400 text-sm">{(error as Error).message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return <TopologyMap data={data} />;
+}
+```
+
+to:
+
+```typescript
+function Dashboard() {
+  const { data, isLoading, error } = useTopology();
+  const sse = useSSE();
+
+  if (isLoading) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-gray-950">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-gray-600 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-400 text-sm">Loading topology from LibreNMS...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-gray-950">
+        <div className="text-center max-w-md px-4">
+          <p className="text-red-400 text-lg font-semibold mb-2">Failed to load topology</p>
+          <p className="text-gray-400 text-sm">{(error as Error).message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return <TopologyMap data={data} sse={sse} />;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat: wire useSSE in Dashboard, pass to TopologyMap"
+```
+
+---
+
+### Task 6: Frontend — Update TopologyMap to accept SSE props and forward to AssetEventToast
+
+**Files:**
+- Modify: `frontend/src/components/TopologyMap.tsx`
+
+- [ ] **Step 1: Update the Props interface**
+
+Change the Props interface (around line 18-20) from:
+
+```typescript
+interface Props {
+  data: TopologyResponse;
+}
+```
+
+to:
+
+```typescript
+import type { AssetEvent } from "@librenms-dash/shared";
+
+interface SSEState {
+  allEvents: AssetEvent[];
+  connected: boolean;
+}
+
+interface Props {
+  data: TopologyResponse;
+  sse: SSEState;
+}
+```
+
+- [ ] **Step 2: Destructure sse from props**
+
+Change the component signature (around line 52) from:
+
+```typescript
+export function TopologyMap({ data }: Props) {
+```
+
+to:
+
+```typescript
+export function TopologyMap({ data, sse }: Props) {
+```
+
+- [ ] **Step 3: Pass SSE props to AssetEventToast**
+
+Change the `<AssetEventToast />` usage (line 1216) from:
+
+```tsx
+      <AssetEventToast />
+```
+
+to:
+
+```tsx
+      <AssetEventToast allEvents={sse.allEvents} connected={sse.connected} />
+```
+
+- [ ] **Step 4: Verify frontend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p frontend/tsconfig.json`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/TopologyMap.tsx
+git commit -m "feat: forward SSE state to AssetEventToast via props"
+```
+
+---
+
+### Task 7: Frontend — Defer layout recomputation during drag
+
+**Files:**
+- Modify: `frontend/src/hooks/useForceLayout.ts:643-729`
+- Modify: `frontend/src/components/TopologyMap.tsx`
+
+- [ ] **Step 1: Add isDragging parameter to useForceLayout**
+
+Change the `useForceLayout` function signature (line 643-649) from:
+
+```typescript
+export function useForceLayout(
+  data: TopologyResponse | undefined,
+  containerWidth: number,
+  containerHeight: number,
+  showArpDevices = false,
+  topReserve = 56,
+) {
+```
+
+to:
+
+```typescript
+export function useForceLayout(
+  data: TopologyResponse | undefined,
+  containerWidth: number,
+  containerHeight: number,
+  showArpDevices = false,
+  topReserve = 56,
+  isDragging = false,
+) {
+```
+
+- [ ] **Step 2: Add pending data ref and defer logic in the layout effect**
+
+After the `layoutSigRef` declaration (line 673), add:
+
+```typescript
+  const pendingDataRef = useRef<TopologyResponse | undefined>();
+```
+
+Then modify the main layout `useEffect` (lines 694-729). Change it from:
+
+```typescript
+  useEffect(() => {
+    if (!data || !containerWidth) return;
+    // Skip regenerating the layout (which discards manual drags/resizes) when the
+    // topology and layout inputs are unchanged — e.g. on the 5-minute background poll.
+    const sig = layoutSignature(data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve);
+    if (sig === layoutSigRef.current) return;
+    layoutSigRef.current = sig;
+```
+
+to:
+
+```typescript
+  useEffect(() => {
+    if (!data || !containerWidth) return;
+    if (isDragging) {
+      pendingDataRef.current = data;
+      return;
+    }
+    const effectiveData = pendingDataRef.current ?? data;
+    pendingDataRef.current = undefined;
+    const sig = layoutSignature(effectiveData, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve);
+    if (sig === layoutSigRef.current) return;
+    layoutSigRef.current = sig;
+```
+
+Also update the rest of the effect to use `effectiveData` instead of `data`. The `layoutAll` call on what was line 701 changes from:
+
+```typescript
+    const result = layoutAll(data, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
+```
+
+to:
+
+```typescript
+    const result = layoutAll(effectiveData, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
+```
+
+- [ ] **Step 3: Add isDragging to the effect dependency array**
+
+Change the dependency array of the layout effect (line 729) from:
+
+```typescript
+  }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve]);
+```
+
+to:
+
+```typescript
+  }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve, isDragging]);
+```
+
+- [ ] **Step 4: Pass isDragging from TopologyMap**
+
+In `frontend/src/components/TopologyMap.tsx`, the `dragTarget` ref is defined around line 141. The `useForceLayout` call needs to know whether a drag is active.
+
+Add a state variable near the other state declarations:
+
+```typescript
+  const [isDragging, setIsDragging] = useState(false);
+```
+
+Update the `useForceLayout` call to pass it. Find the existing call (should be around the area after the dimension/topInset setup):
+
+```typescript
+  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices, topInset);
+```
+
+Change to:
+
+```typescript
+  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices, topInset, isDragging);
+```
+
+Set `isDragging` to `true` when a drag starts and `false` when it ends. In the three `beginXxxDrag` functions (around lines 511, 532, 553), after setting `dragTarget.current`, add:
+
+```typescript
+    setIsDragging(true);
+```
+
+In the `handleMouseUp` function (around line 623 where `dragTarget.current = null`), add before that line:
+
+```typescript
+    setIsDragging(false);
+```
+
+- [ ] **Step 5: Verify frontend compiles**
+
+Run: `cd /home/jkumar/Librenms-dash && npx tsc --noEmit -p frontend/tsconfig.json`
+Expected: No errors.
+
+- [ ] **Step 6: Verify full build**
+
+Run: `cd /home/jkumar/Librenms-dash && pnpm build`
+Expected: Clean build, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/hooks/useForceLayout.ts frontend/src/components/TopologyMap.tsx
+git commit -m "feat: defer layout recomputation during drag"
+```

--- a/docs/superpowers/specs/2026-06-15-sse-topology-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-15-sse-topology-refresh-design.md
@@ -1,0 +1,175 @@
+# SSE-Triggered Topology Refresh
+
+## Problem
+
+When the backend detects topology changes (devices added/removed, overlay links changed, ARP neighbors discovered), the frontend does not update until the user manually refreshes the browser. The React Query 5-minute `refetchInterval` in `useTopology` is meant to catch changes, but the delay is too long and users expect near-real-time updates.
+
+The backend already has the infrastructure to detect changes (`diffAndLog` in `poller.ts`) and push events over SSE (`/api/events/stream`). The SSE stream is currently used only for asset-change toast notifications. The topology data itself is never pushed — the frontend must poll for it.
+
+## Design Decisions
+
+- **SSE-triggered invalidation, not SSE-streamed data.** The backend sends a lightweight `topology-changed` signal over the existing SSE stream. The frontend reacts by calling `queryClient.invalidateQueries(["topology"])`, which triggers a standard HTTP re-fetch of the full topology. This avoids duplicating serialization logic, keeps payloads on the efficient HTTP path (with compression), and requires minimal code change.
+- **Single SSE connection, two consumers.** The EventSource currently lives inside `AssetEventToast`. It needs to be lifted into a shared hook so both asset toasts and topology invalidation share one connection.
+- **Preserve user positions on live updates.** The existing `layoutSignature` + `usePersistedLayout` mechanisms already handle this — no new persistence logic needed.
+- **Defer updates during drag.** If the user is mid-drag when a topology-changed event arrives, defer the layout recomputation until the drag ends to avoid jarring position snaps.
+- **Keep 5-minute polling as fallback.** The `refetchInterval` in `useTopology` stays. If SSE disconnects or misses an event, the polling catches up.
+
+## Architecture
+
+### Data Flow
+
+```
+LibreNMS API
+    │
+    ▼ (every 5 min)
+Backend Poller (pollDevicesAndLocations, pollPortsAndIps, pollRoutes)
+    │
+    ├── diffAndLog() detects changes
+    │       │
+    │       ├── pushEvents() → SSE "events" → AssetEventToast (existing)
+    │       └── pushTopologyChanged() → SSE "topology-changed" (new)
+    │
+    ▼
+Frontend useSSE hook
+    │
+    ├── "events" → asset event state → AssetEventToast component
+    └── "topology-changed" → queryClient.invalidateQueries(["topology"])
+                                    │
+                                    ▼
+                              useTopology re-fetches GET /api/topology
+                                    │
+                                    ▼
+                              useForceLayout checks layoutSignature
+                                    │
+                                    ├── unchanged → no re-render
+                                    └── changed → recompute layout
+                                              │
+                                              ▼
+                                        usePersistedLayout applies saved positions
+                                              │
+                                              ▼
+                                        Map updates with positions preserved
+```
+
+### Backend Changes
+
+#### `backend/src/jobs/poller.ts`
+
+Add a topology-changed broadcast mechanism parallel to the existing asset event system:
+
+```typescript
+type TopologyListener = () => void;
+const topologyListeners = new Set<TopologyListener>();
+
+export function subscribeTopologyChanged(fn: TopologyListener) { topologyListeners.add(fn); }
+export function unsubscribeTopologyChanged(fn: TopologyListener) { topologyListeners.delete(fn); }
+
+let topologyChangedInCycle = false;
+
+function diffAndLog(category: string, prev: Set<string>, curr: Set<string>): Set<string> {
+  // ... existing logic ...
+  // After detecting adds or removes, set the flag:
+  if (events.length > 0) topologyChangedInCycle = true;
+  // ... rest unchanged ...
+}
+```
+
+Add flush calls at the end of each poll function (`pollDevicesAndLocations`, `pollPortsAndIps`, `pollRoutes`):
+
+```typescript
+function flushTopologyChanged() {
+  if (!topologyChangedInCycle) return;
+  topologyChangedInCycle = false;
+  for (const fn of topologyListeners) fn();
+}
+```
+
+#### `backend/src/routes/events.ts`
+
+Subscribe to topology-changed alongside the existing asset events:
+
+```typescript
+const onTopologyChanged = () => {
+  stream.writeSSE({ data: JSON.stringify({ ts: new Date().toISOString() }), event: "topology-changed" }).catch(() => {});
+};
+
+subscribeTopologyChanged(onTopologyChanged);
+stream.onAbort(() => {
+  unsubscribeEvents(onEvents);
+  unsubscribeTopologyChanged(onTopologyChanged);
+});
+```
+
+### Frontend Changes
+
+#### New: `frontend/src/hooks/useSSE.ts`
+
+Manages the single EventSource connection. Returns asset events for the toast component. Handles topology-changed by invalidating React Query.
+
+```typescript
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const [assetEvents, setAssetEvents] = useState<AssetEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+
+    es.addEventListener("init", (e) => { /* parse and set initial asset events */ });
+    es.addEventListener("events", (e) => { /* parse and append new asset events */ });
+    es.addEventListener("topology-changed", () => {
+      queryClient.invalidateQueries({ queryKey: ["topology"] });
+    });
+
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    return () => { es.close(); setConnected(false); };
+  }, [queryClient]);
+
+  return { assetEvents, connected, setAssetEvents };
+}
+```
+
+#### Modified: `frontend/src/components/AssetEventToast.tsx`
+
+Remove the internal `useEffect` that creates an EventSource. Instead, receive `assetEvents` and `connected` as props from the parent. All toast queue/display logic stays unchanged.
+
+#### Modified: `frontend/src/App.tsx`
+
+Call `useSSE()` in `Dashboard` and pass results down to `AssetEventToast`.
+
+#### Modified: `frontend/src/hooks/useForceLayout.ts`
+
+Add mid-drag deferral. Accept a `isDragging` flag (or ref). When true, store pending data but skip the layout effect. When dragging ends, apply the pending update.
+
+```typescript
+// In the layout effect:
+useEffect(() => {
+  if (!data || !containerWidth) return;
+  if (isDragging) {
+    pendingDataRef.current = data;
+    return;
+  }
+  // ... existing layout logic ...
+}, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve, isDragging]);
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/jobs/poller.ts` | Add `topologyListeners`, `subscribeTopologyChanged`, `unsubscribeTopologyChanged`, `flushTopologyChanged`. Set flag in `diffAndLog`. Call `flushTopologyChanged()` at end of each poll function. |
+| `backend/src/routes/events.ts` | Subscribe to topology-changed in the SSE stream handler. |
+| `frontend/src/hooks/useSSE.ts` **(new)** | Shared EventSource hook. Handles `init`, `events`, `topology-changed`. Returns asset events and connection state. |
+| `frontend/src/components/AssetEventToast.tsx` | Remove internal EventSource. Accept asset events and connection state as props. |
+| `frontend/src/App.tsx` | Call `useSSE()` in Dashboard. Pass asset event props to `AssetEventToast`. |
+| `frontend/src/hooks/useForceLayout.ts` | Add `isDragging` parameter. Defer layout recomputation during drag. |
+| `frontend/src/components/TopologyMap.tsx` | Pass `isDragging` (derived from `dragTarget.current`) to `useForceLayout`. |
+
+### What This Does NOT Change
+
+- Backend polling intervals (stays at 5 min for devices/ports, 2 min for alerts)
+- The `GET /api/topology` endpoint or its response shape
+- The `layoutSignature` mechanism or `usePersistedLayout` logic
+- Toast notification behavior (toasts still work, just sourced from shared hook)
+- The 5-minute React Query `refetchInterval` fallback

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useTopology } from "@/hooks/useTopology";
+import { useSSE } from "@/hooks/useSSE";
 import { useAuth } from "@/context/AuthContext";
 import { TopologyMap } from "@/components/TopologyMap";
 import { LoginPage } from "@/components/LoginPage";
@@ -17,6 +18,7 @@ function AuthLoadingScreen({ message }: { message: string }) {
 
 function Dashboard() {
   const { data, isLoading, error } = useTopology();
+  const sse = useSSE();
 
   if (isLoading) {
     return (
@@ -42,7 +44,7 @@ function Dashboard() {
 
   if (!data) return null;
 
-  return <TopologyMap data={data} />;
+  return <TopologyMap data={data} sse={sse} />;
 }
 
 export function App() {

--- a/frontend/src/components/AssetEventToast.tsx
+++ b/frontend/src/components/AssetEventToast.tsx
@@ -22,15 +22,18 @@ function formatTs(iso: string) {
   });
 }
 
-export function AssetEventToast() {
-  const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
+interface AssetEventToastProps {
+  allEvents: AssetEvent[];
+  connected: boolean;
+}
+
+export function AssetEventToast({ allEvents, connected }: AssetEventToastProps) {
   const [queue, setQueue] = useState<AssetEvent[]>([]);
   const [toast, setToast] = useState<AssetEvent | null>(null);
   const [toastVisible, setToastVisible] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
   const [page, setPage] = useState(0);
   const [newCount, setNewCount] = useState(0);
-  const [connected, setConnected] = useState(false);
   const toastHovered = useRef(false);
   const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inGap = useRef(false);
@@ -49,34 +52,19 @@ export function AssetEventToast() {
     }, 300);
   }, [clearDismiss]);
 
-  const addEvents = useCallback((events: AssetEvent[]) => {
-    setAllEvents(prev => [...prev, ...events].slice(-200));
-    setNewCount(prev => prev + events.length);
+  const prevLengthRef = useRef(allEvents.length);
+  useEffect(() => {
+    const prevLen = prevLengthRef.current;
+    prevLengthRef.current = allEvents.length;
+    if (allEvents.length <= prevLen) return;
+    const newEvents = allEvents.slice(prevLen);
+    if (newEvents.length === 0) return;
+    setNewCount(prev => prev + newEvents.length);
     setQueue(prev => {
-      const merged = [...prev, ...events];
+      const merged = [...prev, ...newEvents];
       return merged.length > MAX_QUEUE ? merged.slice(-MAX_QUEUE) : merged;
     });
-  }, []);
-
-  // SSE connection
-  useEffect(() => {
-    const es = new EventSource("/api/events/stream");
-    es.addEventListener("init", (e) => {
-      try {
-        const events: AssetEvent[] = JSON.parse(e.data);
-        if (events.length > 0) setAllEvents(events);
-      } catch { /* ignore */ }
-    });
-    es.addEventListener("events", (e) => {
-      try {
-        const events: AssetEvent[] = JSON.parse(e.data);
-        if (events.length > 0) addEvents(events);
-      } catch { /* ignore */ }
-    });
-    es.onopen = () => setConnected(true);
-    es.onerror = () => setConnected(false);
-    return () => { es.close(); setConnected(false); };
-  }, [addEvents]);
+  }, [allEvents]);
 
   // Show next toast from queue
   useEffect(() => {

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { MouseEvent } from "react";
-import type { TopologyResponse, DeviceSummary } from "@librenms-dash/shared";
+import type { TopologyResponse, DeviceSummary, AssetEvent } from "@librenms-dash/shared";
 import { useForceLayout } from "@/hooks/useForceLayout";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useTransformPersistence, readPersistedTransform, clearPersistedTransform, consumeFitTransformRequest } from "@/hooks/usePersistedLayout";
@@ -15,8 +15,14 @@ import { curvedLinkPath, pointToPointPath, computeDominantSide, DEVICE_HALF, ARP
 import { Logo } from "./Logo";
 import { AssetEventToast } from "./AssetEventToast";
 
+interface SSEState {
+  allEvents: AssetEvent[];
+  connected: boolean;
+}
+
 interface Props {
   data: TopologyResponse;
+  sse: SSEState;
 }
 
 const GRID_SIZE = 24;
@@ -59,7 +65,7 @@ function snapToNearby(value: number, candidates: number[]): number | null {
   return best;
 }
 
-export function TopologyMap({ data }: Props) {
+export function TopologyMap({ data, sse }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const topBarRef = useRef<HTMLDivElement>(null);
@@ -1213,7 +1219,7 @@ export function TopologyMap({ data }: Props) {
       </div>
 
       {/* Asset change toasts — above copyright bar */}
-      <AssetEventToast />
+      <AssetEventToast allEvents={sse.allEvents} connected={sse.connected} />
 
       {/* Bottom-right: GPLv3 copyright, GitHub link, commit SHA */}
       <div className="absolute bottom-2 right-2 z-10 pointer-events-auto flex items-center gap-2 text-[10px] text-gray-500">

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -96,6 +96,7 @@ export function TopologyMap({ data, sse }: Props) {
   const [showArp, setShowArp] = useLocalStorage("librenms-dash:showArp:v1", false);
   const [showArpDevices, setShowArpDevices] = useLocalStorage("librenms-dash:showArpDevices:v1", false);
   const [snapToGrid, setSnapToGrid] = useLocalStorage("librenms-dash:snapToGrid:v1", false);
+  const [isDragging, setIsDragging] = useState(false);
   // ── Ephemeral UI state (not persisted) ──────────────────────────────────────
   const linkDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const linkTooltipHovered = useRef(false);
@@ -197,7 +198,7 @@ export function TopologyMap({ data, sse }: Props) {
     moveDevice,
     resizeSite,
     toggleSiteOrientation,
-  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices, topInset);
+  } = useForceLayout(data, dimensions.width, dimensions.height, showArpDevices, topInset, isDragging);
 
   // When the layout regenerates (new topology, orientation change, reset), snap
   // the SVG transform back to the computed fit-scale so nothing overflows.
@@ -524,6 +525,7 @@ export function TopologyMap({ data, sse }: Props) {
       currentX: site.x,
       currentY: site.y,
     };
+    setIsDragging(true);
     didPan.current = false;
     isPanning.current = false;
     setHoveredDevice(null);
@@ -545,6 +547,7 @@ export function TopologyMap({ data, sse }: Props) {
       currentX: node.x,
       currentY: node.y,
     };
+    setIsDragging(true);
     didPan.current = false;
     isPanning.current = false;
     setHoveredDevice(null);
@@ -568,6 +571,7 @@ export function TopologyMap({ data, sse }: Props) {
       startWidth: site.width,
       startHeight: site.height,
     };
+    setIsDragging(true);
     didPan.current = false;
     isPanning.current = false;
     setHoveredDevice(null);
@@ -626,6 +630,7 @@ export function TopologyMap({ data, sse }: Props) {
 
   const handleMouseUp = useCallback(() => {
     isPanning.current = false;
+    setIsDragging(false);
     dragTarget.current = null;
   }, []);
 

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -646,6 +646,7 @@ export function useForceLayout(
   containerHeight: number,
   showArpDevices = false,
   topReserve = 56,
+  isDragging = false,
 ) {
   const persist = usePersistedLayout();
 
@@ -671,6 +672,7 @@ export function useForceLayout(
   const arpDeviceNodesRef = useRef(arpDeviceNodes);
   arpDeviceNodesRef.current = arpDeviceNodes;
   const layoutSigRef = useRef<string>("");
+  const pendingDataRef = useRef<TopologyResponse | undefined>();
 
   const relinkNodes = useCallback((nextNodes: LayoutNode[]) => {
     const nodeMap = new Map(nextNodes.map((node) => [node.hostname, node]));
@@ -693,12 +695,18 @@ export function useForceLayout(
 
   useEffect(() => {
     if (!data || !containerWidth) return;
+    if (isDragging) {
+      pendingDataRef.current = data;
+      return;
+    }
+    const effectiveData = pendingDataRef.current ?? data;
+    pendingDataRef.current = undefined;
     // Skip regenerating the layout (which discards manual drags/resizes) when the
     // topology and layout inputs are unchanged — e.g. on the 5-minute background poll.
-    const sig = layoutSignature(data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve);
+    const sig = layoutSignature(effectiveData, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve);
     if (sig === layoutSigRef.current) return;
     layoutSigRef.current = sig;
-    const result = layoutAll(data, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
+    const result = layoutAll(effectiveData, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
     // Overlay saved positions on top of freshly-computed ones so manual drags
     // and resizes from a previous session are restored after reload.
     const restoredSites = persist.applySitePositions(result.sites);
@@ -726,7 +734,7 @@ export function useForceLayout(
     setArpDeviceNodes(arp.arpNodes);
     setDeviceGroups(restoredGroups);
     setInitialScale(result.initialScale);
-  }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve]);
+  }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve, isDragging]);
 
   const resetLayout = useCallback(() => {
     if (!data || !containerWidth) return;

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { AssetEvent } from "@librenms-dash/shared";
+
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+  const addEventsRef = useRef<(events: AssetEvent[]) => void>();
+
+  const addEvents = useCallback((events: AssetEvent[]) => {
+    setAllEvents(prev => {
+      const merged = [...prev, ...events];
+      return merged.length > 200 ? merged.slice(-200) : merged;
+    });
+  }, []);
+
+  addEventsRef.current = addEvents;
+
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+
+    es.addEventListener("init", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) setAllEvents(events);
+      } catch { /* ignore */ }
+    });
+
+    es.addEventListener("events", (e) => {
+      try {
+        const events: AssetEvent[] = JSON.parse(e.data);
+        if (events.length > 0) addEventsRef.current?.(events);
+      } catch { /* ignore */ }
+    });
+
+    es.addEventListener("topology-changed", () => {
+      queryClient.invalidateQueries({ queryKey: ["topology"] });
+    });
+
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    return () => { es.close(); setConnected(false); };
+  }, [queryClient]);
+
+  return { allEvents, connected };
+}


### PR DESCRIPTION
## Summary

- When the backend poller detects topology changes (devices, ports, overlays, ARP, routes), it now broadcasts a `topology-changed` event over the existing SSE stream
- The frontend listens for this event and immediately re-fetches topology via React Query invalidation — no browser refresh needed
- Layout positions are preserved during live updates; mid-drag updates are deferred until the drag ends

## Changes

**Backend (2 files):**
- `poller.ts` — Added `subscribeTopologyChanged`/`unsubscribeTopologyChanged` listener set. `diffAndLog` sets a per-cycle flag; `flushTopologyChanged()` broadcasts at end of each poll function
- `events.ts` — SSE stream subscribes to topology-changed and emits it to connected clients

**Frontend (5 files):**
- `useSSE.ts` **(new)** — Shared EventSource hook handling `init`, `events`, and `topology-changed`. On topology-changed, calls `queryClient.invalidateQueries(["topology"])`
- `AssetEventToast.tsx` — Removed internal EventSource; now receives `allEvents` and `connected` via props
- `App.tsx` — Calls `useSSE()` in Dashboard, passes state to TopologyMap
- `TopologyMap.tsx` — Forwards SSE state to AssetEventToast; passes `isDragging` to useForceLayout
- `useForceLayout.ts` — Accepts `isDragging` param; defers layout recomputation during drag, applies pending data when drag ends

## Test plan

- [ ] Start the app, verify topology loads normally
- [ ] Add/remove a device in LibreNMS, wait for next backend poll cycle (~5 min), verify the map updates without browser refresh
- [ ] Verify asset change toasts still appear for added/removed assets
- [ ] Drag a device while a topology update arrives — verify the drag isn't interrupted
- [ ] Verify the SSE connection indicator (green dot in the event bar) shows connected status
- [ ] Verify the 5-minute fallback polling still works if SSE disconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)