### PR TITLE
fix: multi-bug fixes for Docker, L2 discovery, tooltips, and routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir -p /app/data && \
 
 # build frontend + backend
 FROM deps AS build
+ARG COMMIT_SHA
 COPY shared/ shared/
 COPY frontend/ frontend/
 COPY backend/ backend/
@@ -35,6 +36,8 @@ COPY --from=build /app/frontend/dist frontend/dist/
 COPY --from=build /app/shared shared/
 COPY --from=oui /app/data data/
 
+ARG COMMIT_SHA
+ENV COMMIT_SHA=${COMMIT_SHA}
 ENV NODE_ENV=production
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 EXPOSE 3001

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -237,6 +237,16 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
     }
   }
 
+  // Map port_id → first local IPv4 on that port (for seenByIp on discovered devices).
+  const portIdToIp = new Map<number, string>();
+  for (const [, ips] of allIps) {
+    for (const ip of ips) {
+      if (!ip.ipv4_address || portIdToIp.has(ip.port_id)) continue;
+      if (engine.isOverlayIp(ip.ipv4_address) || isDockerIp(ip.ipv4_address)) continue;
+      portIdToIp.set(ip.port_id, ip.ipv4_address);
+    }
+  }
+
   // Active devices provide IP→hostname mapping for ARP link building.
   // Only map local IPs (skip overlay, docker-bridge, and excluded interfaces)
   // so ARP links stay on physical/LAN paths.
@@ -382,7 +392,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   }
 
   // --- Consolidation: union-find to merge MACs sharing an IP and IPs sharing a MAC ---
-  const arpDevices = consolidateArpDevices(allArpEntries, managedIpsByLocation, managedMacsByLocation, deviceIdToHostname, hostnameToLocation, isOverlayIp, portIdToIfName, activeDeviceIds);
+  const arpDevices = consolidateArpDevices(allArpEntries, managedIpsByLocation, managedMacsByLocation, deviceIdToHostname, hostnameToLocation, isOverlayIp, portIdToIfName, portIdToMac, portIdToIp, activeDeviceIds);
 
   cache.set("arpLinks", arpLinks, TTL.PORTS);
   cache.set("arpDevices", arpDevices, TTL.PORTS);
@@ -404,6 +414,8 @@ function consolidateArpDevices(
   hostnameToLocation: Map<string, string>,
   isOverlayIp: (ip: string) => boolean,
   portIdToIfName: Map<number, string>,
+  portIdToMac: Map<number, string>,
+  portIdToIp: Map<number, string>,
   activeDeviceIds: Set<number>,
 ): ArpDiscoveredDevice[] {
   // Phase 1: collect valid (mac, ip) pairs, grouped by location.
@@ -531,6 +543,8 @@ function consolidateArpDevices(
         siteId,
         seenByHostname: seenBy,
         seenByInterface: portIdToIfName.get(comp.portId),
+        seenByIp: portIdToIp.get(comp.portId),
+        seenByMac: portIdToMac.get(comp.portId),
       });
     }
   }

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -1,6 +1,6 @@
 import { cache, TTL } from "../cache/store.js";
 import { librenmsGet, delay } from "../librenms/client.js";
-import { buildOverlayLinks, engine } from "../librenms/overlays.js";
+import { buildOverlayLinks, engine, isExcludedIface, isDockerIp, findLanIp } from "../librenms/overlays.js";
 import { loadOuiDatabases, lookupVendor, normalizeMac } from "../librenms/oui.js";
 import { makeCidrMatcher } from "../librenms/cidr.js";
 import { ARP_EXCLUDED_SUBNETS, OVERLAY_SUBNET_LIST } from "../config.js";
@@ -221,25 +221,46 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   // Active device IDs — used to restrict which devices can be "seenBy" sources
   const activeDeviceIds = new Set(devices.map((d) => d.device_id));
 
-  // Active devices also provide IP→hostname mapping for ARP link building
-  for (const d of devices) {
-    ipToHostname.set(d.ip, d.hostname);
-    const ips = allIps.get(d.hostname) ?? [];
-    for (const ip of ips) {
-      ipToHostname.set(ip.ipv4_address, d.hostname);
-    }
-  }
-
   // Map each port_id to its interface name (from the per-device port cache) so
   // ARP links/devices can report which interface a device learned a peer on.
+  // Built early because ipToHostname filtering needs it.
   const portIdToIfName = new Map<number, string>();
+  const portIdToMac = new Map<number, string>();
   for (const d of allDevicesForExclusion) {
     const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
     if (!ports) continue;
     for (const p of ports) {
       const name = p.ifName || p.ifDescr;
       if (name) portIdToIfName.set(p.port_id, name);
+      const mac = normalizeMac(p.ifPhysAddress ?? "");
+      if (mac && mac.length === 12 && mac !== "000000000000") portIdToMac.set(p.port_id, mac);
     }
+  }
+
+  // Active devices provide IP→hostname mapping for ARP link building.
+  // Only map local IPs (skip overlay, docker-bridge, and excluded interfaces)
+  // so ARP links stay on physical/LAN paths.
+  for (const d of devices) {
+    if (!engine.isOverlayIp(d.ip) && !isDockerIp(d.ip)) {
+      ipToHostname.set(d.ip, d.hostname);
+    }
+    const ips = allIps.get(d.hostname) ?? [];
+    for (const ip of ips) {
+      if (!ip.ipv4_address) continue;
+      if (engine.isOverlayIp(ip.ipv4_address)) continue;
+      if (isDockerIp(ip.ipv4_address)) continue;
+      const ifName = portIdToIfName.get(ip.port_id) ?? "";
+      if (ifName && isExcludedIface(ifName)) continue;
+      ipToHostname.set(ip.ipv4_address, d.hostname);
+    }
+  }
+
+  // Pre-compute each device's local (LAN) IP for ARP link toIp field.
+  const hostnameToLocalIp = new Map<string, string>();
+  for (const d of devices) {
+    const ips = allIps.get(d.hostname) ?? [];
+    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`) ?? [];
+    hostnameToLocalIp.set(d.hostname, findLanIp(d.ip, ips, ports));
   }
 
   const linkSet = new Set<string>();
@@ -274,18 +295,30 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
         if (!seeingHostname || seeingHostname === ownerHostname) continue;
         if (hostnameToLocation.get(seeingHostname) !== hostnameToLocation.get(ownerHostname)) continue;
 
+        // Only build links from local interfaces
+        const ifName = portIdToIfName.get(entry.port_id) ?? "";
+        if (ifName && isExcludedIface(ifName)) continue;
+
         const key = [ownerHostname, seeingHostname].sort().join("<>");
         if (linkSet.has(key)) continue;
         linkSet.add(key);
 
-        const seeingDevice = devices.find(d => d.hostname === seeingHostname);
+        const ownerIps = allIps.get(ownerHostname) ?? [];
+        const ownerPortId = ownerIps.find(i => i.ipv4_address === ip)?.port_id;
+        const fromIfName = ownerPortId ? portIdToIfName.get(ownerPortId) : undefined;
+        const fromMac = ownerPortId ? portIdToMac.get(ownerPortId) : undefined;
+        const toMac = portIdToMac.get(entry.port_id);
+
         arpLinks.push({
           fromHostname: ownerHostname,
           toHostname: seeingHostname,
           fromIp: ip,
-          toIp: seeingDevice?.ip ?? "",
+          toIp: hostnameToLocalIp.get(seeingHostname) ?? "",
           mac: entry.mac_address,
-          toInterface: portIdToIfName.get(entry.port_id),
+          fromInterface: fromIfName,
+          fromMac: fromMac ?? entry.mac_address,
+          toInterface: ifName || undefined,
+          toMac,
         });
       }
     } catch {
@@ -389,9 +422,9 @@ function consolidateArpDevices(
     if (isBogus(mac)) continue;
     if (isOverlayIp(ip)) continue;
 
-    // Skip MACs learned on ZeroTier interfaces
+    // Skip entries learned on overlay or docker bridge interfaces
     const ifName = portIdToIfName.get(entry.port_id);
-    if (ifName && /^zt/i.test(ifName)) continue;
+    if (ifName && isExcludedIface(ifName)) continue;
 
     const seenBy = deviceIdToHostname.get(entry.device_id);
     if (!seenBy) continue;

--- a/backend/src/librenms/overlays.ts
+++ b/backend/src/librenms/overlays.ts
@@ -58,24 +58,36 @@ export function getOverlayPortSummaries(
   return [...best.values()];
 }
 
-export function findLanIp(deviceIp: string, ips: LnmsDeviceIp[]): string {
+export function findLanIp(deviceIp: string, ips: LnmsDeviceIp[], ports?: LnmsPort[]): string {
+  const portIdToIfName = new Map<number, string>();
+  if (ports) {
+    for (const p of ports) {
+      const name = p.ifName || p.ifDescr;
+      if (name) portIdToIfName.set(p.port_id, name);
+    }
+  }
+
   const lanIps: string[] = [];
   for (const entry of ips) {
     const addr = entry.ipv4_address;
     if (!addr || addr === "127.0.0.1") continue;
-    if (!engine.isOverlayIp(addr)) {
-      lanIps.push(addr);
+    if (engine.isOverlayIp(addr)) continue;
+    if (isDockerIp(addr)) continue;
+    if (ports) {
+      const ifName = portIdToIfName.get(entry.port_id) ?? "";
+      if (ifName && isExcludedIface(ifName)) continue;
     }
+    lanIps.push(addr);
   }
-  if (!engine.isOverlayIp(deviceIp) && deviceIp) return deviceIp;
+  if (!engine.isOverlayIp(deviceIp) && !isDockerIp(deviceIp) && deviceIp) return deviceIp;
   if (lanIps.length > 0) return lanIps[0];
   return deviceIp;
 }
 
 const DOCKER_IFACE_RE = /^(br-[0-9a-f]{6,}|docker|veth)/i;
-const isDockerIp = makeCidrMatcher(DOCKER_SUBNETS);
+export const isDockerIp = makeCidrMatcher(DOCKER_SUBNETS);
 
-function isExcludedIface(ifName: string): boolean {
+export function isExcludedIface(ifName: string): boolean {
   if (ifName === "lo") return true;
   if (DOCKER_IFACE_RE.test(ifName)) return true;
   return engine.classifyPort({ ifName } as LnmsPort) !== null;

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -1,15 +1,11 @@
 import { Hono } from "hono";
-import { execSync } from "node:child_process";
 import { cache } from "../cache/store.js";
 import type { TopologyResponse, Site, DeviceSummary, SubnetGroup, NeighborLink, ArpLink, ArpDiscoveredDevice, DeviceRoute } from "@librenms-dash/shared";
 import type { LnmsDevice, LnmsPort, LnmsLocation, LnmsAlert, LnmsDeviceIp, LnmsLink } from "../librenms/types.js";
-import { getOverlayPortSummaries, findLanIp, findDeviceIps } from "../librenms/overlays.js";
+import { getOverlayPortSummaries, findLanIp, findDeviceIps, isExcludedIface } from "../librenms/overlays.js";
 import { normalizeMac } from "../librenms/oui.js";
 
-let commitSha: string | undefined;
-try {
-  commitSha = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
-} catch { /* not a git repo or git unavailable */ }
+const commitSha: string | undefined = process.env.COMMIT_SHA || undefined;
 
 const app = new Hono();
 
@@ -64,7 +60,7 @@ app.get("/", (c) => {
       hostname: device.hostname,
       displayName: deriveDisplayName(device),
       ip: device.ip,
-      lanIp: findLanIp(device.ip, ips),
+      lanIp: findLanIp(device.ip, ips, ports),
       ips: findDeviceIps(ips, ports),
       macs: [...macSet],
       os: device.os,
@@ -103,6 +99,11 @@ app.get("/", (c) => {
     const remoteDev = deviceIdMap.get(link.remote_device_id);
     if (!localDev || !remoteDev) continue;
 
+    const localPortName = portNameMap.get(link.local_port_id) ?? "";
+    const remotePortName = portNameMap.get(link.remote_port_id) ?? link.remote_port ?? "";
+    if (localPortName && isExcludedIface(localPortName)) continue;
+    if (remotePortName && isExcludedIface(remotePortName)) continue;
+
     const key = [link.local_device_id, link.remote_device_id].sort().join("-") +
       ":" + [link.local_port_id, link.remote_port_id].sort().join("-");
     if (neighborSet.has(key)) continue;
@@ -112,10 +113,10 @@ app.get("/", (c) => {
       id: link.id,
       localDeviceId: link.local_device_id,
       localHostname: localDev.hostname,
-      localPort: portNameMap.get(link.local_port_id) ?? `port-${link.local_port_id}`,
+      localPort: localPortName || `port-${link.local_port_id}`,
       remoteDeviceId: link.remote_device_id,
       remoteHostname: remoteDev.hostname,
-      remotePort: portNameMap.get(link.remote_port_id) ?? link.remote_port ?? `port-${link.remote_port_id}`,
+      remotePort: remotePortName || `port-${link.remote_port_id}`,
       protocol: link.protocol,
     });
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 services:
   librenms-dash:
-    build: .
+    build:
+      context: .
+      args:
+        COMMIT_SHA: ${COMMIT_SHA:-}
     container_name: librenms-dash
     restart: unless-stopped
     ports:

--- a/frontend/src/components/LinkTooltip.tsx
+++ b/frontend/src/components/LinkTooltip.tsx
@@ -24,6 +24,7 @@ export interface LinkTooltipData {
   // ARP discovered device
   interface?: string;
   vendor?: string;
+  sourceMac?: string;
 }
 
 const OVERLAY_LABELS: Record<string, string> = {
@@ -70,6 +71,7 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             <Row label="Device" value={data.sourceDisplayName} />
             {data.interface && <Row label="Interface" value={data.interface} mono />}
             {data.sourceIp && <Row label="IP" value={data.sourceIp} mono />}
+            {data.sourceMac && <Row label="MAC" value={data.sourceMac} mono />}
             <SectionLabel label="Discovered device" />
             <Row label="Vendor" value={data.vendor || data.targetDisplayName || "Unknown"} />
             <Row label="IP" value={data.targetIp ?? "—"} mono />

--- a/frontend/src/components/LinkTooltip.tsx
+++ b/frontend/src/components/LinkTooltip.tsx
@@ -15,6 +15,7 @@ export interface LinkTooltipData {
   sourceIp?: string;
   targetIp?: string;
   mac?: string;
+  targetMac?: string;
   // Overlay
   overlayType?: string;
   // Per-endpoint interface (LLDP ports, overlay/ARP interfaces)
@@ -75,6 +76,21 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             <Row label="MAC" value={data.mac ?? "—"} mono />
           </tbody>
         </table>
+      ) : data.type === "arp" ? (
+        <table className="w-full border-collapse text-xs">
+          <tbody>
+            <SectionLabel label="Device" />
+            <Row label="Name" value={data.sourceDisplayName} />
+            {data.sourceInterface && <Row label="Interface" value={data.sourceInterface} mono />}
+            {data.sourceIp && <Row label="IP" value={data.sourceIp} mono />}
+            {data.mac && <Row label="MAC" value={data.mac} mono />}
+            <SectionLabel label="Seen by" />
+            <Row label="Device" value={data.targetDisplayName} />
+            {data.targetInterface && <Row label="Interface" value={data.targetInterface} mono />}
+            {data.targetIp && <Row label="IP" value={data.targetIp} mono />}
+            {data.targetMac && <Row label="MAC" value={data.targetMac} mono />}
+          </tbody>
+        </table>
       ) : (
         <table className="w-full border-collapse text-xs">
           <tbody>
@@ -84,7 +100,6 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
               iface={data.sourceInterface}
               ip={data.sourceIp}
               ipLabel={data.type === "overlay" ? "Overlay IP" : "IP"}
-              mac={data.type === "arp" ? data.mac : undefined}
             />
             <DeviceSection
               role="Destination"

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -1018,10 +1018,11 @@ export function TopologyMap({ data, sse }: Props) {
                     sourceDisplayName: displayName(ad.seenByHostname),
                     targetDisplayName: ad.vendor || "Unknown device",
                     color: ARP_COLOR,
-                    sourceIp: parentDev?.ips?.[0] ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+                    sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
                     targetIp: ad.ips.join(", "),
                     mac: formatMac(ad.mac),
                     interface: ad.seenByInterface,
+                    sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
                     vendor: ad.vendor,
                   })}
                   onMouseLeave={hideLinkTooltip}
@@ -1051,10 +1052,11 @@ export function TopologyMap({ data, sse }: Props) {
               sourceDisplayName: displayName(ad.seenByHostname),
               targetDisplayName: ad.vendor || "Unknown device",
               color: ARP_COLOR,
-              sourceIp: parentDev?.ips?.[0] ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+              sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
               targetIp: ad.ips.join(", "),
               mac: formatMac(ad.mac),
               interface: ad.seenByInterface,
+              sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
               vendor: ad.vendor,
             });
             return (

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -920,9 +920,11 @@ export function TopologyMap({ data, sse }: Props) {
                   targetDisplayName: displayName(al.target.hostname),
                   color: ARP_COLOR,
                   sourceIp: al.fromIp,
+                  sourceInterface: al.fromInterface,
                   targetIp: al.toIp,
                   targetInterface: al.toInterface,
-                  mac: formatMac(al.mac),
+                  mac: formatMac(al.fromMac ?? al.mac),
+                  targetMac: al.toMac ? formatMac(al.toMac) : undefined,
                 })}
                 onMouseLeave={hideLinkTooltip}
               />

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -670,10 +670,15 @@ export function TopologyMap({ data, sse }: Props) {
       if (!s) { s = { lldp: 0, arp: 0, discovered: 0, routes: 0 }; map.set(id, s); }
       return s;
     };
-    // Seed every site so the header shows counts (including zeros) for all locations.
     for (const site of data.sites) {
       const b = bucket(site.id);
-      for (const dev of site.devices) b.routes += dev.routes?.length ?? 0;
+      const seen = new Set<string>();
+      for (const dev of site.devices) {
+        for (const r of dev.routes ?? []) {
+          const key = `${r.dest}/${r.prefix}>${r.nextHop}`;
+          if (!seen.has(key)) { seen.add(key); b.routes++; }
+        }
+      }
     }
     for (const nl of neighborLinks) {
       for (const id of new Set([nl.source.siteId, nl.target.siteId])) bucket(id).lldp++;
@@ -686,11 +691,15 @@ export function TopologyMap({ data, sse }: Props) {
   }, [neighborLinks, arpLinks, data.arpDevices, data.sites]);
 
   const totalRoutes = useMemo(() => {
-    let count = 0;
+    const seen = new Set<string>();
     for (const site of data.sites) {
-      for (const dev of site.devices) count += dev.routes?.length ?? 0;
+      for (const dev of site.devices) {
+        for (const r of dev.routes ?? []) {
+          seen.add(`${r.dest}/${r.prefix}>${r.nextHop}`);
+        }
+      }
     }
-    return count;
+    return seen.size;
   }, [data.sites]);
 
   return (

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -39,7 +39,10 @@ export interface ArpLayoutLink {
   fromIp: string;
   toIp: string;
   mac: string;
+  fromInterface?: string;
+  fromMac?: string;
   toInterface?: string;
+  toMac?: string;
 }
 
 export interface SiteCluster {
@@ -394,7 +397,10 @@ function layoutAll(
         fromIp: a.fromIp,
         toIp: a.toIp,
         mac: a.mac,
+        fromInterface: a.fromInterface,
+        fromMac: a.fromMac,
         toInterface: a.toInterface,
+        toMac: a.toMac,
       });
     }
   }

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -71,6 +71,8 @@ export interface ArpDeviceLayoutNode {
   siteId: string;
   seenByHostname: string;
   seenByInterface?: string;
+  seenByIp?: string;
+  seenByMac?: string;
   x: number;
   y: number;
 }
@@ -340,6 +342,8 @@ function layoutAll(
           siteId: site.id,
           seenByHostname: ad.seenByHostname,
           seenByInterface: ad.seenByInterface,
+          seenByIp: ad.seenByIp,
+          seenByMac: ad.seenByMac,
           x: arpStartX + ARP_NODE_W / 2 + col * (ARP_NODE_W + ARP_NODE_GAP_X),
           y: arpStartY + ARP_SECTION_LABEL_H + ARP_SECTION_PAD + ARP_NODE_H / 2 + row * (ARP_NODE_H + ARP_NODE_GAP_Y),
         });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -141,7 +141,10 @@ export interface ArpLink {
   fromIp: string;
   toIp: string;
   mac: string;
+  fromInterface?: string;
+  fromMac?: string;
   toInterface?: string;
+  toMac?: string;
 }
 
 export interface ArpDiscoveredDevice {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -156,6 +156,8 @@ export interface ArpDiscoveredDevice {
   siteId: string;
   seenByHostname: string;
   seenByInterface?: string;
+  seenByIp?: string;
+  seenByMac?: string;
 }
 
 export interface TopologyResponse {


### PR DESCRIPTION
## Summary
- **Docker git stderr fix**: Replace `execSync("git rev-parse --short HEAD")` with `COMMIT_SHA` env var injected at build time, eliminating `/bin/sh: git: not found` noise in container logs
- **Local-only L2 discovery**: Filter overlay (ZeroTier, WireGuard, Tailscale) and Docker bridge interfaces from LLDP/CDP neighbor links and ARP link building so topology maps only local interfaces and IPs
- **ARP link tooltip enrichment**: Show interface name and MAC address for both "Device" and "Seen by" sides of ARP link tooltips, correlated from port data
- **Discovered device tooltip IP fix**: Resolve seen-by IP from the actual interface port (`vlan0.40` → `192.168.40.1`) instead of using the device's first IP; add MAC on both sides
- **Route count deduplication**: Deduplicate route counts by `dest/prefix + nextHop` in both the top bar global total and per-site headers (101 raw → 37 unique globally)

## Test plan
- [x] `docker-compose up -d --build` succeeds with no stderr noise
- [x] `commitSha` field present in `/api/topology` response
- [x] Zero overlay/Docker interfaces in LLDP/CDP neighbor links
- [x] ARP links use only local interfaces and corresponding IPs
- [x] ARP link tooltip shows interface + MAC on both Device and Seen by sections
- [x] Discovered device tooltip shows correct per-interface IP (verified vlan0.40 → 192.168.40.1)
- [x] Discovered device tooltip shows MAC on both sides (128/129 populated)
- [x] Route counts deduplicated (e.g. BLR-R: 33 raw → 12 unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)