### PR TITLE
feat: device search with multi-match cycling and pulsating highlight

### DIFF
--- a/frontend/src/components/ArpDeviceNode.tsx
+++ b/frontend/src/components/ArpDeviceNode.tsx
@@ -4,6 +4,7 @@ import type { ArpDeviceLayoutNode } from "@/hooks/useForceLayout";
 interface Props {
   node: ArpDeviceLayoutNode;
   highlighted?: boolean;
+  searchMatch?: boolean;
   onMouseEnter?: (e: React.MouseEvent) => void;
   onMouseLeave?: () => void;
   onClick?: (e: React.MouseEvent) => void;
@@ -12,7 +13,7 @@ interface Props {
 const BOX_W = 132;
 const BOX_H = 42;
 
-export function ArpDeviceNode({ node, highlighted, onMouseEnter, onMouseLeave, onClick }: Props) {
+export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, onMouseLeave, onClick }: Props) {
   const [isHovered, setIsHovered] = useState(false);
   const x = node.x - BOX_W / 2;
   const y = node.y - BOX_H / 2;
@@ -22,6 +23,7 @@ export function ArpDeviceNode({ node, highlighted, onMouseEnter, onMouseLeave, o
   const ipDisplay = node.ips.length > 1
     ? `${node.ips[0]} +${node.ips.length - 1}`
     : node.ips[0] ?? "";
+  const active = isHovered || highlighted || searchMatch;
 
   const handleEnter = useCallback((e: React.MouseEvent) => {
     setIsHovered(true);
@@ -40,26 +42,41 @@ export function ArpDeviceNode({ node, highlighted, onMouseEnter, onMouseLeave, o
       onClick={onClick}
       style={{ cursor: "pointer" }}
     >
+      {searchMatch && (
+        <rect
+          x={x - 6}
+          y={y - 6}
+          width={BOX_W + 12}
+          height={BOX_H + 12}
+          rx={9}
+          fill="#facc15"
+          fillOpacity={0.08}
+          stroke="#facc15"
+          strokeWidth={2}
+          className="search-match-glow"
+        />
+      )}
       <rect
         x={x}
         y={y}
         width={BOX_W}
         height={BOX_H}
         rx={6}
-        fill={isHovered || highlighted ? "#1e293b" : "#0f172a"}
-        fillOpacity={isHovered ? 0.88 : highlighted ? 0.8 : 0.65}
-        stroke="#fbbf24"
-        strokeWidth={isHovered || highlighted ? 1.5 : 1}
-        strokeOpacity={isHovered || highlighted ? 0.8 : 0.4}
+        fill={active ? "#1e293b" : "#0f172a"}
+        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : 0.65}
+        stroke={searchMatch ? "#facc15" : "#fbbf24"}
+        strokeWidth={searchMatch ? 2.5 : active ? 1.5 : 1}
+        strokeOpacity={active ? 0.8 : 0.4}
+        className={searchMatch ? "search-match-box" : undefined}
       />
       {/* Vendor */}
       <text
         x={x + 5}
         y={y + 12}
-        fill="#fbbf24"
+        fill={searchMatch ? "#facc15" : "#fbbf24"}
         fillOpacity={0.9}
-        fontSize={8.5}
-        fontWeight={600}
+        fontSize={searchMatch ? 9.5 : 8.5}
+        fontWeight={searchMatch ? 700 : 600}
         fontFamily="system-ui, sans-serif"
       >
         {vendorShort || "Unknown"}

--- a/frontend/src/components/DeviceNode.tsx
+++ b/frontend/src/components/DeviceNode.tsx
@@ -9,6 +9,7 @@ interface Props {
   device?: DeviceSummary;
   interactive?: boolean;
   highlighted?: boolean;
+  searchMatch?: boolean;
   onHover: (hostname: string | null) => void;
   onMouseDown?: (event: MouseEvent<SVGGElement>) => void;
   onClick?: (event: MouseEvent<SVGGElement>) => void;
@@ -30,7 +31,7 @@ const OVERLAY_LABELS: Record<string, string> = {
   tailscale: "TS",
 };
 
-export function DeviceNode({ node, device, interactive = true, highlighted, onHover, onMouseDown, onClick }: Props) {
+export function DeviceNode({ node, device, interactive = true, highlighted, searchMatch, onHover, onMouseDown, onClick }: Props) {
   const [isHovered, setIsHovered] = useState(false);
   const x = (node.x ?? 0) - BOX_W / 2;
   const y = (node.y ?? 0) - BOX_H / 2;
@@ -49,6 +50,7 @@ export function DeviceNode({ node, device, interactive = true, highlighted, onHo
   const displayName = device?.displayName ?? node.hostname;
   const deviceIps = device?.ips?.length ? device.ips : [device?.lanIp ?? device?.ip ?? ""];
   const overlayPorts = (device?.overlayPorts ?? []).filter((p) => p.ip);
+  const active = isHovered || highlighted || searchMatch;
 
   return (
     <g
@@ -58,17 +60,32 @@ export function DeviceNode({ node, device, interactive = true, highlighted, onHo
       onMouseLeave={handleLeave}
       style={{ cursor: interactive ? "move" : "pointer" }}
     >
+      {searchMatch && (
+        <rect
+          x={x - 6}
+          y={y - 6}
+          width={BOX_W + 12}
+          height={BOX_H + 12}
+          rx={9}
+          fill="#facc15"
+          fillOpacity={0.08}
+          stroke="#facc15"
+          strokeWidth={2}
+          className="search-match-glow"
+        />
+      )}
       <rect
         x={x}
         y={y}
         width={BOX_W}
         height={BOX_H}
         rx={5}
-        fill={isHovered || highlighted ? "#1e293b" : "#0f172a"}
-        fillOpacity={isHovered ? 0.92 : highlighted ? 0.88 : 0.78}
-        stroke={statusColor}
-        strokeWidth={isHovered || highlighted ? 2 : 1.5}
-        strokeOpacity={isHovered || highlighted ? 1 : 0.65}
+        fill={searchMatch ? "#1e293b" : active ? "#1e293b" : "#0f172a"}
+        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.92 : highlighted ? 0.88 : 0.78}
+        stroke={searchMatch ? "#facc15" : statusColor}
+        strokeWidth={searchMatch ? 2.5 : active ? 2 : 1.5}
+        strokeOpacity={active ? 1 : 0.65}
+        className={searchMatch ? "search-match-box" : undefined}
       />
 
       {/* Icon */}
@@ -84,9 +101,9 @@ export function DeviceNode({ node, device, interactive = true, highlighted, onHo
       <text
         x={x + 6 + ICON_SIZE + 5}
         y={y + 18}
-        fill="#f1f5f9"
-        fontSize={11}
-        fontWeight={600}
+        fill={searchMatch ? "#facc15" : "#f1f5f9"}
+        fontSize={searchMatch ? 12 : 11}
+        fontWeight={searchMatch ? 700 : 600}
         fontFamily="system-ui, sans-serif"
       >
         {displayName.length > 13 ? displayName.slice(0, 12) + "…" : displayName}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -47,6 +47,10 @@ function formatMac(mac: string): string {
   return clean.match(/.{2}/g)!.join(":");
 }
 
+function normalizeMacSearch(input: string): string {
+  return input.replace(/[:\-.\s]/g, "").toLowerCase();
+}
+
 function readViewportSize(): { width: number; height: number } {
   if (typeof window === "undefined") return { width: 1200, height: 800 };
   return { width: window.innerWidth, height: window.innerHeight };
@@ -106,6 +110,9 @@ export function TopologyMap({ data, sse }: Props) {
   const alertHoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const alertDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const alertTooltipHovered = useRef(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const prevCommitSha = useRef(data.commitSha);
   const [shaChanged, setShaChanged] = useState(false);
 
@@ -218,6 +225,95 @@ export function TopologyMap({ data, sse }: Props) {
     }
     return map;
   }, [data.sites]);
+
+  const searchMatches = useMemo(() => {
+    const q = searchQuery.trim();
+    if (!q) return [];
+    const qLower = q.toLowerCase();
+    const qMac = normalizeMacSearch(q);
+    const looksLikeMac = /^[0-9a-f]{2,}$/i.test(qMac) && qMac.length >= 4;
+    const matches: string[] = [];
+
+    for (const site of data.sites) {
+      for (const dev of site.devices) {
+        if (
+          dev.hostname.toLowerCase().includes(qLower) ||
+          dev.displayName.toLowerCase().includes(qLower) ||
+          dev.sysName?.toLowerCase().includes(qLower) ||
+          dev.ip?.includes(qLower) ||
+          dev.lanIp?.includes(qLower) ||
+          dev.ips?.some((ip) => ip.includes(qLower)) ||
+          (looksLikeMac && dev.macs?.some((m) => normalizeMacSearch(m).includes(qMac)))
+        ) {
+          matches.push(dev.hostname);
+        }
+      }
+    }
+
+    for (const ad of data.arpDevices ?? []) {
+      if (
+        ad.vendor?.toLowerCase().includes(qLower) ||
+        ad.ips?.some((ip) => ip.includes(qLower)) ||
+        (looksLikeMac && (
+          normalizeMacSearch(ad.mac).includes(qMac) ||
+          ad.macs?.some((m) => normalizeMacSearch(m).includes(qMac))
+        ))
+      ) {
+        matches.push(ad.mac);
+      }
+    }
+
+    return matches;
+  }, [searchQuery, data.sites, data.arpDevices]);
+
+  const [searchMatchIndex, setSearchMatchIndex] = useState(0);
+
+  useEffect(() => {
+    setSearchMatchIndex(0);
+  }, [searchMatches]);
+
+  const searchMatchId = searchMatches.length > 0 ? searchMatches[searchMatchIndex % searchMatches.length] : null;
+
+  const centerOnMatch = useCallback((matchId: string) => {
+    const node = nodes.find((n) => n.hostname === matchId);
+    if (node) {
+      setTransform((prev) => ({
+        scale: prev.scale,
+        x: dimensions.width / 2 - node.x * prev.scale,
+        y: dimensions.height / 2 - node.y * prev.scale,
+      }));
+      return;
+    }
+    const arpNode = arpDeviceNodes.find((ad) => ad.mac === matchId);
+    if (arpNode) {
+      setTransform((prev) => ({
+        scale: prev.scale,
+        x: dimensions.width / 2 - arpNode.x * prev.scale,
+        y: dimensions.height / 2 - arpNode.y * prev.scale,
+      }));
+    }
+  }, [nodes, arpDeviceNodes, dimensions]);
+
+  useEffect(() => {
+    if (searchMatchId) centerOnMatch(searchMatchId);
+  }, [searchMatchId, centerOnMatch]);
+
+  const handleSearchEnter = useCallback(() => {
+    if (searchMatches.length <= 1) return;
+    setSearchMatchIndex((prev) => (prev + 1) % searchMatches.length);
+  }, [searchMatches]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "f") {
+        e.preventDefault();
+        setSearchOpen(true);
+        setTimeout(() => searchInputRef.current?.focus(), 0);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const displayName = useCallback((hostname: string) => {
     return deviceMap.get(hostname)?.displayName ?? hostname;
@@ -796,7 +892,7 @@ export function TopologyMap({ data, sse }: Props) {
         </button>
       </div>
 
-      {/* Status */}
+      {/* Status + Search */}
       <div className="flex flex-wrap items-center gap-4 bg-gray-900/90 backdrop-blur border border-gray-700 rounded-lg px-4 py-2 text-xs pointer-events-auto">
         <span className="text-gray-400">
           {data.sites.length} sites, {data.sites.reduce((s, site) => s + site.devices.length, 0)} devices
@@ -811,6 +907,54 @@ export function TopologyMap({ data, sse }: Props) {
           </span>
         )}
         <span className="text-gray-500">Updated {new Date(data.lastUpdated).toLocaleTimeString()}</span>
+        <span className="text-gray-700">|</span>
+        {searchOpen ? (
+          <span className="flex items-center gap-1.5">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") { setSearchQuery(""); setSearchOpen(false); }
+                if (e.key === "Enter") handleSearchEnter();
+                e.stopPropagation();
+              }}
+              placeholder="Name, IP, or MAC..."
+              className="bg-gray-800 border border-gray-600 rounded px-2 py-0.5 text-xs text-gray-200 placeholder-gray-500 outline-none focus:border-yellow-500 w-44"
+              autoFocus
+            />
+            {searchQuery && searchMatches.length === 0 && (
+              <span className="text-red-400">No match</span>
+            )}
+            {searchQuery && searchMatches.length === 1 && (
+              <span className="text-green-400">1 match</span>
+            )}
+            {searchQuery && searchMatches.length > 1 && (
+              <span className="text-yellow-400 tabular-nums">
+                {(searchMatchIndex % searchMatches.length) + 1}/{searchMatches.length}
+                <span className="text-gray-500 ml-1">↵</span>
+              </span>
+            )}
+            <button
+              onClick={() => { setSearchQuery(""); setSearchOpen(false); }}
+              className="text-gray-500 hover:text-gray-300 ml-0.5"
+              title="Close search"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+          </span>
+        ) : (
+          <button
+            onClick={() => { setSearchOpen(true); setTimeout(() => searchInputRef.current?.focus(), 0); }}
+            className="flex items-center gap-1.5 text-gray-400 hover:text-white transition-colors"
+            title="Search devices (Ctrl+F)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            Search
+          </button>
+        )}
       </div>
       </div>
 
@@ -988,6 +1132,7 @@ export function TopologyMap({ data, sse }: Props) {
               device={deviceMap.get(node.hostname)}
               interactive={snapToGrid}
               highlighted={highlightedId === node.hostname}
+              searchMatch={searchMatchId === node.hostname}
               onHover={handleDeviceHover}
               onMouseDown={(e) => beginDeviceDrag(node.hostname, e)}
               onClick={(e) => handleDeviceClick(node.hostname, e)}
@@ -1073,6 +1218,7 @@ export function TopologyMap({ data, sse }: Props) {
                 key={ad.mac}
                 node={ad}
                 highlighted={highlightedId === ad.mac || highlightedId === ad.seenByHostname}
+                searchMatch={searchMatchId === ad.mac}
                 onMouseEnter={() => setHighlightedId(ad.mac)}
                 onMouseLeave={() => setHighlightedId(pinnedId.current)}
                 onClick={(e) => handleArpClick(ad.mac, tooltip(e), e)}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -7,3 +7,21 @@ html, body, #root {
   padding: 0;
   overflow: hidden;
 }
+
+@keyframes search-pulse-glow {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+@keyframes search-pulse-box {
+  0%, 100% { filter: brightness(1) drop-shadow(0 0 3px rgba(250,204,21,0.3)); }
+  50% { filter: brightness(1.25) drop-shadow(0 0 10px rgba(250,204,21,0.7)); }
+}
+
+.search-match-glow {
+  animation: search-pulse-glow 1.5s ease-in-out infinite;
+}
+
+.search-match-box {
+  animation: search-pulse-box 1.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
- Add search field to topology map for finding devices by name, IP, or MAC address (with or without colons/dashes)
- Searches both monitored hosts and ARP discovered devices
- Centers matched device on screen without changing zoom level
- When multiple devices match a partial query, press Enter to cycle through them (displays `2/5 ↵` counter)
- Matched device highlighted with pulsating brightness/glow animation instead of static border
- Open via Search button in status bar or Ctrl+F keyboard shortcut

## Test plan
- [ ] Open topology map, click Search (or Ctrl+F), type a partial hostname — verify matching device is centered and pulsates
- [ ] Type a partial IP address — verify correct device is found
- [ ] Type a MAC address with colons (e.g. `aa:bb:cc`) and without (`aabbcc`) — verify both formats match
- [ ] With multiple matches, press Enter repeatedly — verify cycling through all matches with counter updating
- [ ] Press Escape — verify search closes and highlight clears
- [ ] Enable Discovered devices layer, search for an ARP device by vendor/IP/MAC — verify it highlights with pulsating glow
- [ ] Verify `docker-compose up -d --build` compiles and runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)