### PR TITLE
Topology layout overhaul: A4 boxes, elastic boundaries, dynamic collision separation

### DIFF
--- a/docs/superpowers/plans/2026-06-19-dynamic-collision-separation.md
+++ b/docs/superpowers/plans/2026-06-19-dynamic-collision-separation.md
@@ -1,0 +1,187 @@
+# Dynamic Collision Separation for Layout Boxes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve overlapping layout boxes (site / device / discovered) dynamically
+by pushing colliding siblings apart with minimal displacement, preserving the user's
+saved arrangement, instead of discarding the saved layout when an overlap is detected.
+
+**Architecture:** A pure minimum-translation-vector (MTV) separation primitive
+(`separateBoxes`) is applied hierarchically by `resolveCollisions`: separate device
++ discovered boxes within each site, grow the site to contain them (A4 as a floor),
+then separate site boxes and translate each site's contents with it — iterated until
+stable. Runs render-time over the restored layout and after every drag/resize/toggle,
+with the dragged entity anchored. Non-destructive to localStorage. Replaces the
+`sitesOverlap` discard fallback. See
+`docs/superpowers/specs/2026-06-19-dynamic-collision-separation-design.md`.
+
+**Tech Stack:** React, TypeScript, SVG. No new runtime dependencies (custom AABB
+relaxation, not `d3-force`).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `frontend/src/hooks/layout/separation.ts` | Create | Pure `separateBoxes()` MTV relaxation, `Box` type, overlap helpers |
+| `frontend/src/hooks/layout/separation.test.ts` | Create (if test infra present) | Unit tests for the primitive |
+| `frontend/src/hooks/useForceLayout.ts` | Modify | `resolveCollisions`, `fitSitesToContents`; wire into effect + move/resize; remove discard branch |
+| `frontend/src/components/TopologyMap.tsx` | Verify only | Confirm drag handlers need no change |
+
+---
+
+### Task 1: Separation primitive (pure, isolated)
+
+**Files:** Create `frontend/src/hooks/layout/separation.ts`
+
+- [ ] **Step 1: Box type + overlap helper.**
+
+```ts
+export interface Box { id: string; x: number; y: number; width: number; height: number; }
+
+export function boxesOverlap(a: Box, b: Box, margin = 0): boolean {
+  const ox = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) + margin;
+  const oy = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) + margin;
+  return ox > 0 && oy > 0;
+}
+
+export function anyOverlap(boxes: Box[], margin = 0): boolean {
+  for (let i = 0; i < boxes.length; i++)
+    for (let j = i + 1; j < boxes.length; j++)
+      if (boxesOverlap(boxes[i], boxes[j], margin)) return true;
+  return false;
+}
+```
+
+- [ ] **Step 2: `separateBoxes` relaxation.** Implement the MTV loop from the spec.
+  Operate on a local copy of `{x,y}`; return `Map<id,{dx,dy}>` of net displacement
+  (omit zero entries). Honour `margin`, `anchorId`, `maxIters` (default 50). Push
+  along the least-penetration axis; split evenly unless one box is the anchor.
+  Use a deterministic pair order (index order); break when a full pass moves nothing.
+
+- [ ] **Step 3: Self-check the invariants in code comments** — idempotent (no overlap
+  ⇒ empty map), anchored box has no entry, symmetric split is order-independent.
+
+**Verify:** `anyOverlap(result)` is false after applying displacements for a set of
+overlapping boxes; an already-separated set yields an empty map.
+
+---
+
+### Task 2: Unit tests for the primitive (only if a test runner exists)
+
+**Files:** Create `frontend/src/hooks/layout/separation.test.ts`
+
+- [ ] **Step 1:** Check `frontend/package.json` for a `test` script / vitest. If none,
+  **skip this task** and rely on Task 5's browser verification (note the skip).
+- [ ] **Step 2:** Cases: (a) two boxes overlapping on X separate along X; (b) overlap
+  on Y separates along Y; (c) already-separated ⇒ empty map (idempotent); (d) anchored
+  box does not move, neighbour absorbs full push; (e) a row of three mutually
+  overlapping boxes ends with `anyOverlap == false`; (f) margin leaves a visible gap.
+
+**Verify:** `pnpm --filter frontend test` (or equivalent) green.
+
+---
+
+### Task 3: `resolveCollisions` + containment in `useForceLayout`
+
+**Files:** Modify `frontend/src/hooks/useForceLayout.ts`
+
+- [ ] **Step 1: `fitSitesToContents`.** Add alongside `fitSitesToDeviceGroups`. Same
+  bounding-box logic but also include each site's discovered boxes, and clamp the
+  resulting width/height to **at least** the site's current A4 size (A4 as a floor,
+  grow-only). Reuse `toA4` to keep the floor A4-shaped.
+
+- [ ] **Step 2: `resolveCollisions(sites, groups, nodes, arpNodes, anchor?)`.**
+  Implement the inside-out pipeline from the spec:
+  1. Per site: `separateBoxes([...siteNodes, ...siteArpNodes], { margin: NODE_GAP_X, anchorId: anchor?.node })`; apply displacements.
+  2. `groups = fitDeviceGroupsToNodes(groups, nodes)`.
+  3. `sites = fitSitesToContents(sites, groups, arpNodes)`.
+  4. `const siteDisp = separateBoxes(sites, { margin: SITE_GAP, anchorId: anchor?.site })`; for each displaced site, translate the site **and** its groups, nodes, arpNodes by the same vector.
+  5. Repeat step 4 (sizes now fixed) until `anyOverlap(sites, SITE_GAP)` is false or a small iteration cap.
+  Return the updated arrays. Map device/site entities to `Box` via `{id|hostname|mac, x - width/2, y - height/2, width, height}` for nodes (nodes are center-anchored) and `{id, x, y, width, height}` for sites/groups (top-left anchored) — be careful with the two coordinate conventions.
+
+- [ ] **Step 3: Fast-path guard.** At the top of `resolveCollisions`, if
+  `!anyOverlap(siteBoxes, SITE_GAP)` and no per-site child overlap, return the inputs
+  unchanged (common case — costs one scan).
+
+**Verify:** Pure-ish; exercised via Task 5.
+
+---
+
+### Task 4: Wire `resolveCollisions` into the layout lifecycle
+
+**Files:** Modify `frontend/src/hooks/useForceLayout.ts`
+
+- [ ] **Step 1: Layout effect — replace the discard fallback.** In the rebuild
+  effect, after `relayoutArpNodes(...)`, **remove** the `if (sitesOverlap(arp.sites)) { …setResult…; return; }` block added previously. Replace with:
+
+```ts
+const resolved = resolveCollisions(arp.sites, restoredGroups, restoredNodes, arp.arpNodes);
+setSites(resolved.sites);
+setNodes(resolved.nodes);
+setLinks(result.links.map(rebind));        // rebind to resolved.nodes
+setNeighborLinks(result.neighborLinks.map(rebind));
+setArpLinks(result.arpLinks.map(rebind));
+setArpDeviceNodes(resolved.arpNodes);
+setDeviceGroups(resolved.groups);
+setInitialScale(result.initialScale);
+```
+
+Ensure `rebind`/`relinkNodes` use `resolved.nodes` (links derive from node positions).
+
+- [ ] **Step 2: `moveSite`** — after translating the site + contents, call
+  `resolveCollisions(..., { site: siteId })` and set the resolved arrays. Persist the
+  dragged site (existing) — neighbours move in-memory only until the user drags them.
+
+- [ ] **Step 3: `moveDevice`** — after the existing node/group/site refit, call
+  `resolveCollisions(..., { node: hostname })`. Set resolved arrays; keep existing
+  persistence of the dragged node + sites.
+
+- [ ] **Step 4: `resizeSite`** — after reflow + A4 re-snap, call
+  `resolveCollisions(..., { site: siteId })` so the enlarged box pushes neighbours.
+
+- [ ] **Step 5: Keep `sitesOverlap`** as the guard inside `resolveCollisions`/fast-path
+  (do not delete it — only its discard usage in the effect is removed).
+
+**Verify:** `pnpm --filter frontend build` (tsc) clean; then Task 5.
+
+---
+
+### Task 5: Verify in the browser (runtime observation)
+
+> Use the **verify** skill. App runs in Docker (`docker-compose up -d --build`,
+> host network, port 3001, login `admin`/`changeme`). Drive headless Chrome over CDP
+> (pattern already established in scratchpad scripts). Read site/device rects from
+> `svg rect[rx="8"]` (sites) and device/discovered rects; compute pairwise overlap in
+> natural SVG coordinates.
+
+- [ ] **Step 1: No-overlap on rebuild.** Inject an overlapping saved layout into
+  `localStorage["librenms-dash:layout:v1"]` (all sites piled on one spot), reload,
+  assert **zero** site overlaps AND that the boxes are *near* their injected spot
+  (separated, not regenerated from scratch) — proving "kept more or less the same".
+- [ ] **Step 2: Discovered toggle.** With a tight saved layout, toggle Discovered on;
+  assert zero overlaps and zoom/pan preserved (`skipAutoFitOnceRef` still holds).
+- [ ] **Step 3: Orientation flip.** Flip a site to portrait; assert zero overlaps,
+  zoom preserved.
+- [ ] **Step 4: Drag anchoring.** Drag one site onto a neighbour; assert the dragged
+  site stays under the cursor (its rect matches the drag target) and the neighbour
+  moved away (zero overlap).
+- [ ] **Step 5: Idempotence.** Trigger two consecutive rebuilds (e.g. toggle Discovered
+  off→on→off) and assert site rects return to the same coordinates (no drift).
+
+**Verify:** All five assertions pass; capture screenshots of the before/after for the
+overlap and drag cases.
+
+---
+
+## Rollback / Risk
+
+- The change is additive + one deletion (the discard branch). If `resolveCollisions`
+  misbehaves, reverting Task 4 Step 1 restores the discard fallback.
+- Determinism risk: ensure `separateBoxes` uses a fixed pair order and the symmetric
+  split, so repeated resolves don't drift. Task 5 Step 5 guards this.
+- Coordinate-convention risk: device **nodes are center-anchored** (`x,y` = center)
+  while site/group boxes are **top-left anchored**. The `Box` adapter in Task 3
+  Step 2 must convert consistently or separation will be offset by half a box.
+```

--- a/docs/superpowers/specs/2026-06-19-dynamic-collision-separation-design.md
+++ b/docs/superpowers/specs/2026-06-19-dynamic-collision-separation-design.md
@@ -1,0 +1,242 @@
+# Dynamic Collision Separation for Layout Boxes
+
+## Problem
+
+The topology map renders nested rectangular boxes — **site** boxes that contain
+**device-group** and **device-node** boxes plus a **discovered-device** section.
+Positions come from a deterministic auto-layout (`layoutAll`) overlaid with the
+user's saved drags/resizes (`usePersistedLayout`).
+
+Overlaps appear whenever the saved layout no longer fits the content:
+
+- Toggling **Discovered** grows a site box downward into the box below it.
+- Flipping a site's **orientation** (A4 portrait ⇄ landscape) changes its footprint.
+- A manually **resized** or **dragged** box ends up on top of a neighbour.
+- A device dragged inside a site lands on another device.
+
+So far we've patched these case-by-case: row spacing reserves the discovered
+section (`totalH`), and a `sitesOverlap()` guard *discards the entire saved layout*
+and falls back to the auto-layout when boxes collide. The discard is blunt — it
+throws away the user's whole arrangement the moment one pair overlaps, and it only
+covers site-vs-site collisions, not device or discovered boxes.
+
+We want a **general, dynamic** mechanism: let the boxes repel one another so that
+any overlap — whatever caused it — is resolved by pushing the colliding boxes apart
+just far enough to clear each other, **preserving the user's intended arrangement as
+closely as possible** instead of regenerating it.
+
+## Goals
+
+- Any two sibling boxes that overlap are separated until they no longer overlap
+  (plus a small margin), at every level of the hierarchy: site↔site,
+  device↔device, device↔discovered, discovered↔discovered.
+- Minimal displacement — boxes move the least distance needed, so a user's layout
+  stays "more or less the same".
+- A parent box always encloses its (separated) children.
+- The pass is **idempotent and deterministic**: running it on an
+  already-separated layout produces zero movement, so it does not drift on every
+  background poll/refresh.
+- During a drag, the box the user is holding does not get pushed — the *others*
+  move out of its way.
+
+## Non-Goals
+
+- Not a physics animation with momentum/jitter. Settling is a render-time
+  constraint solve, not a simulation the user watches bounce.
+- Not viewport-aware. Separation may push content beyond the current viewport;
+  existing pan/zoom (and auto-fit) handle reachability. We never re-introduce an
+  overlap to keep things on-screen.
+- Does not change box *sizing* (A4 ratio, discovered-section height) — only
+  positions. A crowded site may grow to contain separated children (breaking A4),
+  consistent with the existing "discovered extends below" decision.
+
+## Design Decisions
+
+- **Custom AABB separation (constraint relaxation), not `d3-force`.** `d3-force` is
+  a dependency but unused, and its `forceCollide` models *circles*. Our boxes are
+  axis-aligned rectangles with extreme aspect ratios (A4, wide device grids); a
+  circular collider over-separates badly. We instead resolve overlaps with the
+  **minimum translation vector (MTV)** along the axis of least penetration. This is
+  deterministic (no random seed, no alpha schedule), moves boxes the minimum
+  distance (best preserves the user layout), and is trivially idempotent (no
+  overlap ⇒ no move). `d3-force` can be removed from `package.json` in a separate
+  cleanup; this design does not depend on it.
+- **Render-time pass, non-destructive to localStorage.** Separation runs over the
+  restored (persisted ∪ fresh) layout each time the layout is (re)built and after
+  each manipulation. It mutates the in-memory layout state — *not* the saved
+  positions. We never rewrite `localStorage` on load. Resolved positions only
+  become persisted when the user next drags/resizes (the drag handlers already
+  persist the displayed state). This keeps the saved arrangement intact.
+- **Replaces the `sitesOverlap` discard fallback.** The blunt "throw away the saved
+  layout" branch added previously is removed; separation supersedes it. The
+  `sitesOverlap()` predicate is kept and reused as the cheap "is there anything to
+  do?" fast-path guard.
+- **Hierarchical, inside-out.** Children are separated within a parent first, the
+  parent is grown to contain them, then siblings are separated at the next level up
+  — iterated until stable. Resolving the outer level first would let a grown child
+  re-introduce an overlap.
+- **Anchoring.** Each separation accepts an optional `anchorId`. The anchored box is
+  immovable; its colliding neighbours absorb the full MTV. Drag handlers anchor the
+  dragged entity so it tracks the cursor while others give way. With no anchor
+  (plain re-render), the MTV is split evenly between the pair — deterministic and
+  symmetric.
+- **Moving a site moves its contents.** Site-level separation produces a
+  per-site displacement vector; the caller translates each site's device groups,
+  nodes, and discovered boxes by the same vector so the box and its contents stay
+  together.
+
+## Architecture
+
+### Entities & hierarchy
+
+```
+Site box                         ← siblings repel each other (global scope)
+ ├─ Device-group box  ┐
+ ├─ Device-node box   ├─ repel each other within the site (intra-site scope)
+ └─ Discovered box    ┘          parent site grows to contain them
+```
+
+Collision units:
+
+| Scope     | Entities that repel                                  | Container that grows |
+|-----------|------------------------------------------------------|----------------------|
+| Global    | all site boxes                                       | — (free space)       |
+| Intra-site| device-node boxes + discovered-device boxes¹         | the site box         |
+
+¹ Device-group borders are *derived* (they refit to enclose their nodes via
+`fitDeviceGroupsToNodes`), so groups are recomputed after node separation rather
+than separated directly.
+
+### The separation primitive
+
+A pure function over axis-aligned boxes. `Box = { id, x, y, width, height }`.
+
+```ts
+interface SeparateOptions {
+  margin?: number;     // min gap to leave between boxes (default 0)
+  anchorId?: string;   // this box never moves; neighbours absorb the full push
+  maxIters?: number;   // safety cap (default 50)
+}
+
+// Returns a Map<id, {dx, dy}> of net displacements (zero entries omitted).
+function separateBoxes(boxes: Box[], opts?: SeparateOptions): Map<string, {dx:number;dy:number}>
+```
+
+Algorithm (relaxation; iterate until a pass makes no move or `maxIters` hit):
+
+```
+for iter in 0..maxIters:
+  movedThisPass = false
+  for each unordered pair (a, b):
+    ox = min(a.right, b.right) - max(a.left, b.left) + margin
+    oy = min(a.bottom, b.bottom) - max(a.top, b.top) + margin
+    if ox <= 0 or oy <= 0: continue            // not overlapping (within margin)
+    movedThisPass = true
+    if ox < oy:                                 // least-penetration axis = X
+      push = ox
+      dir  = sign(a.centerX - b.centerX) || 1
+      applyPush(a, b, dx = dir * push, axis = X)
+    else:                                        // least-penetration axis = Y
+      push = oy
+      dir  = sign(a.centerY - b.centerY) || 1
+      applyPush(a, b, dy = dir * push, axis = Y)
+  if not movedThisPass: break
+
+applyPush(a, b, delta):
+  if anchorId == a.id:        b moves by -delta
+  elif anchorId == b.id:      a moves by +delta
+  else:                       a moves by +delta/2 ; b moves by -delta/2
+```
+
+Properties: idempotent (no overlap ⇒ `movedThisPass` false on first pass ⇒ break),
+deterministic (stable pair iteration order, no randomness), minimal (MTV along the
+least-penetration axis). Convergence is monotone for the symmetric/anchored split;
+`maxIters` bounds pathological chains.
+
+### Hierarchical resolution pipeline
+
+A single entry point, called wherever the layout is built or mutated:
+
+```
+resolveCollisions(sites, groups, nodes, arpNodes, anchor?):
+  // 1. Intra-site: separate device nodes + discovered boxes within each site.
+  for each site:
+    children = nodes(site) ++ arpNodes(site)
+    disp = separateBoxes(children, { margin: NODE_GAP, anchorId: anchor?.node })
+    apply disp to nodes/arpNodes of this site
+  groups = fitDeviceGroupsToNodes(groups, nodes)     // refit group borders
+  sites  = fitSitesToContents(sites, groups, arpNodes) // grow site to contain (A4 floor)
+
+  // 2. Global: separate site boxes, then translate each site's contents with it.
+  siteDisp = separateBoxes(sites, { margin: SITE_GAP, anchorId: anchor?.site })
+  for each site with siteDisp[id]:
+    translate site + its groups + nodes + arpNodes by siteDisp[id]
+
+  // 3. A grown/translated site may now overlap another → repeat 2 until stable
+  //    (bounded; sizes are fixed in this pass so it converges quickly).
+  return { sites, groups, nodes, arpNodes }
+```
+
+`fitSitesToContents` is `fitSitesToDeviceGroups` extended to also include the
+discovered boxes in the bounding box, with the A4 dimensions as a *floor* (the site
+never shrinks below its A4 size; it only grows to contain).
+
+### Data flow
+
+```
+layoutAll (fresh, A4, never overlaps)
+      │
+      ▼
+applySitePositions / applyNodePositions   ← user's saved drags/resizes
+      │
+      ▼
+relayoutArpNodes                           ← place discovered below content
+      │
+      ▼
+resolveCollisions(...)                     ← NEW: push overlaps apart, contain
+      │   (fast-path: skip if sitesOverlap()==false AND no intra-site overlap)
+      ▼
+setSites / setNodes / setDeviceGroups / setArpDeviceNodes
+```
+
+### Integration points
+
+| Trigger | Today | With this design |
+|---------|-------|------------------|
+| Layout (re)build effect | applies saved positions; **discards them if sites overlap** | applies saved positions, then `resolveCollisions(...)` (no anchor) — discard fallback removed |
+| `moveSite(id, dx, dy)` | translates site + contents | then `resolveCollisions(..., anchor:{site:id})` — neighbours give way |
+| `moveDevice(host, dx, dy)` | translates node, refits group/site | then `resolveCollisions(..., anchor:{node:host})` — sibling devices/discovered give way |
+| `resizeSite(id, w, h)` | reflows content, refits | then `resolveCollisions(..., anchor:{site:id})` — neighbours give way to the larger box |
+| Discovered toggle / orientation flip | grows boxes (can overlap) | layout rebuild runs `resolveCollisions` — growth pushes neighbours apart |
+
+### Idempotence & stability
+
+- On a background poll with an unchanged layout signature, the effect already
+  early-returns (no rebuild). When it does rebuild, `resolveCollisions` over an
+  already-separated layout moves nothing.
+- The fast-path guard (`sitesOverlap` + a cheap intra-site overlap check) skips the
+  whole pass when there is nothing to resolve, so the common case costs one O(n²)
+  scan over a handful of sites.
+- Optional refinement (future): after global separation, translate the whole set so
+  its bounding-box top-left matches the pre-separation top-left, eliminating slow
+  drift of the overall map under repeated resolves.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/hooks/layout/separation.ts` **(new)** | Pure `separateBoxes()` MTV relaxation + `Box` type. No React. Unit-testable. |
+| `frontend/src/hooks/useForceLayout.ts` | Add `resolveCollisions(...)` and `fitSitesToContents(...)`. Call `resolveCollisions` in the layout effect (remove the `sitesOverlap` discard branch), and at the end of `moveSite`, `moveDevice`, `resizeSite` with the appropriate anchor. Keep `sitesOverlap` as the fast-path guard. |
+| `frontend/src/hooks/usePersistedLayout.ts` | None (separation is non-destructive; existing save paths persist the resolved state on next drag). |
+| `frontend/src/components/TopologyMap.tsx` | None required (drag handlers already call `moveSite`/`moveDevice`/`resizeSite`, which now resolve internally). |
+| `frontend/package.json` | Optional follow-up: drop the now-confirmed-unused `d3-force` / `@types/d3-force` deps. Out of scope for this change. |
+
+## What This Does NOT Change
+
+- Box sizing: A4 ratio lock, discovered-section height math, `reflowSiteContents`.
+- The auto-layout (`layoutAll`) — it remains the overlap-free baseline.
+- `usePersistedLayout` storage format or the `layoutSignature` early-return.
+- Zoom/pan behaviour, the `skipAutoFitOnceRef` viewport lock, or auto-fit.
+- The deterministic, non-animated nature of the layout (positions resolve in one
+  synchronous pass; any visual smoothing is a separate CSS-transition concern).
+```

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -137,6 +137,11 @@ export function TopologyMap({ data, sse }: Props) {
   // When a transform was restored from localStorage, don't let auto-fit override
   // it — so a refresh preserves the saved zoom/pan. Cleared on Reset Layout.
   const suppressAutoFit = useRef(restoredTransformRef.current != null);
+  // Some user actions reflow the layout (changing initialScale) but should preserve
+  // the current zoom/pan — toggling discovered devices and flipping a site's
+  // orientation. Set just before such an action and consumed by the auto-fit effect
+  // to skip the one resulting re-fit.
+  const skipAutoFitOnceRef = useRef(false);
   // Debounce-write the transform so pan/zoom doesn't hammer localStorage on every frame.
   useTransformPersistence(transform);
 
@@ -212,6 +217,11 @@ export function TopologyMap({ data, sse }: Props) {
   useEffect(() => {
     if (initialScale === lastInitialScaleRef.current) return;
     lastInitialScaleRef.current = initialScale;
+    if (skipAutoFitOnceRef.current) {
+      // Discovered toggle reflowed the layout — keep the user's current zoom/pan.
+      skipAutoFitOnceRef.current = false;
+      return;
+    }
     if (suppressAutoFit.current) return;
     setTransform({ x: 0, y: 0, scale: initialScale });
   }, [initialScale]);
@@ -751,10 +761,18 @@ export function TopologyMap({ data, sse }: Props) {
   const handleReset = useCallback(() => {
     // Reset Layout should also discard a saved zoom/pan and snap back to fit.
     suppressAutoFit.current = false;
+    skipAutoFitOnceRef.current = false;
     clearPersistedTransform();
     resetLayout();
     setTransform({ x: 0, y: 0, scale: initialScale });
   }, [resetLayout, initialScale]);
+
+  const toggleArpDevices = useCallback(() => {
+    // Reflow the layout to make room for discovered devices, but keep the current
+    // zoom/pan instead of snapping back to fit.
+    skipAutoFitOnceRef.current = true;
+    setShowArpDevices((v) => !v);
+  }, [setShowArpDevices]);
 
   // Per-location counts shown in each site header. Neighbor/ARP links are always
   // computed (independent of the visibility toggles); discovered devices come
@@ -826,7 +844,7 @@ export function TopologyMap({ data, sse }: Props) {
           ARP ({arpLinks.length})
         </button>
         <button
-          onClick={() => setShowArpDevices((v) => !v)}
+          onClick={toggleArpDevices}
           className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ${
             showArpDevices ? "bg-gray-700 text-white" : "bg-gray-800 text-gray-500"
           }`}
@@ -855,15 +873,11 @@ export function TopologyMap({ data, sse }: Props) {
                 visible ? "bg-gray-700 text-white" : "bg-gray-800 text-gray-500"
               }`}
             >
-              <span
-                className="w-3 h-0.5 inline-block rounded self-center"
-                style={{ backgroundColor: color, opacity: visible ? 1 : 0.3 }}
-              />
-              <span className="flex flex-col leading-tight">
+              <span className="flex flex-col items-start leading-tight">
                 <span>{o.label.replace(/\s*\(.*\)\s*$/, "")} ({o.links.length}){o.hub ? " ⭐" : ""}</span>
                 <span
-                  className="text-[9px] font-mono opacity-70"
-                  style={{ color: visible ? color : undefined }}
+                  className="text-[10px] font-mono font-bold"
+                  style={{ color: visible ? color : undefined, opacity: visible ? 1 : 0.5 }}
                 >{o.subnet}</span>
               </span>
             </button>
@@ -1260,6 +1274,9 @@ export function TopologyMap({ data, sse }: Props) {
               index={i}
               onToggleOrientation={(e) => {
                 e.stopPropagation();
+                // Re-orienting reflows the layout (changing initialScale) — keep the
+                // user's current zoom/pan instead of snapping back to fit.
+                skipAutoFitOnceRef.current = true;
                 toggleSiteOrientation(site.id);
               }}
             />

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -874,7 +874,7 @@ export function TopologyMap({ data, sse }: Props) {
               }`}
             >
               <span className="flex flex-col items-start leading-tight">
-                <span>{o.label.replace(/\s*\(.*\)\s*$/, "")} ({o.links.length}){o.hub ? " ⭐" : ""}</span>
+                <span>{o.label.replace(/\s*\(.*\)\s*$/, "")} ({o.links.length})</span>
                 <span
                   className="text-[10px] font-mono font-bold"
                   style={{ color: visible ? color : undefined, opacity: visible ? 1 : 0.5 }}

--- a/frontend/src/hooks/layout/separation.ts
+++ b/frontend/src/hooks/layout/separation.ts
@@ -1,0 +1,101 @@
+// Minimum-translation-vector (MTV) collision separation for axis-aligned boxes.
+//
+// Pure, deterministic, idempotent: given a set of boxes, push any overlapping pair
+// apart along their axis of least penetration until none overlap (plus a margin).
+// No randomness and no animation — this is a constraint solve, not a physics sim.
+// Used by useForceLayout to keep site / device / discovered boxes from overlapping
+// while displacing them the minimum distance (so a user's layout stays put).
+
+export interface Box {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SeparateOptions {
+  /** Minimum gap to leave between boxes. */
+  margin?: number;
+  /** This box never moves; colliding neighbours absorb the full push. */
+  anchorId?: string;
+  /** Safety cap on relaxation passes. */
+  maxIters?: number;
+}
+
+function overlapAmount(a: Box, b: Box, margin: number): { ox: number; oy: number } {
+  const ox = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) + margin;
+  const oy = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) + margin;
+  return { ox, oy };
+}
+
+export function boxesOverlap(a: Box, b: Box, margin = 0): boolean {
+  const { ox, oy } = overlapAmount(a, b, margin);
+  return ox > 0 && oy > 0;
+}
+
+export function anyOverlap(boxes: Box[], margin = 0): boolean {
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      if (boxesOverlap(boxes[i], boxes[j], margin)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve overlaps among `boxes` and return the net displacement per box id
+ * (entries with zero displacement are omitted). The input boxes are not mutated.
+ *
+ * Invariants:
+ *  - No overlap on entry => empty map (idempotent; safe to call every render).
+ *  - The `anchorId` box never appears in the result (it does not move).
+ *  - Without an anchor the push is split evenly between the pair, so the result is
+ *    independent of which box of a pair is listed first (deterministic).
+ */
+export function separateBoxes(boxes: Box[], opts: SeparateOptions = {}): Map<string, { dx: number; dy: number }> {
+  const margin = opts.margin ?? 0;
+  const maxIters = opts.maxIters ?? 50;
+  // Work on a mutable copy of just the positions.
+  const work = boxes.map((b) => ({ ...b }));
+
+  for (let iter = 0; iter < maxIters; iter++) {
+    let movedThisPass = false;
+    for (let i = 0; i < work.length; i++) {
+      for (let j = i + 1; j < work.length; j++) {
+        const a = work[i];
+        const b = work[j];
+        const { ox, oy } = overlapAmount(a, b, margin);
+        if (ox <= 0 || oy <= 0) continue; // not overlapping within margin
+        movedThisPass = true;
+
+        const aAnchored = a.id === opts.anchorId;
+        const bAnchored = b.id === opts.anchorId;
+        // Fraction of the push each box takes.
+        const aShare = aAnchored ? 0 : bAnchored ? 1 : 0.5;
+        const bShare = bAnchored ? 0 : aAnchored ? 1 : 0.5;
+
+        if (ox < oy) {
+          // Separate along X (least penetration).
+          const dir = (a.x + a.width / 2) <= (b.x + b.width / 2) ? -1 : 1;
+          a.x += dir * ox * aShare;
+          b.x -= dir * ox * bShare;
+        } else {
+          // Separate along Y.
+          const dir = (a.y + a.height / 2) <= (b.y + b.height / 2) ? -1 : 1;
+          a.y += dir * oy * aShare;
+          b.y -= dir * oy * bShare;
+        }
+      }
+    }
+    if (!movedThisPass) break;
+  }
+
+  const disp = new Map<string, { dx: number; dy: number }>();
+  for (let i = 0; i < boxes.length; i++) {
+    const dx = work[i].x - boxes[i].x;
+    const dy = work[i].y - boxes[i].y;
+    if (dx !== 0 || dy !== 0) disp.set(boxes[i].id, { dx, dy });
+  }
+  return disp;
+}

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import type { TopologyResponse, DeviceSummary, ArpDiscoveredDevice } from "@librenms-dash/shared";
 import { usePersistedLayout } from "./usePersistedLayout";
+import { separateBoxes, anyOverlap } from "./layout/separation";
 
 export interface LayoutNode {
   id: string;
@@ -97,6 +98,22 @@ const ARP_SECTION_PAD = 8;
 
 export type SiteOrientation = "landscape" | "portrait";
 
+// Site boxes are locked to A4 paper proportions: the long side is √2× the short
+// side. Portrait => height = width · √2; landscape => width = height · √2.
+const A4_RATIO = Math.SQRT2;
+
+// Expand a content box to the smallest A4-proportioned box (for the given
+// orientation) that still contains it. Content stays anchored top-left; the box
+// gains whitespace on the bottom (portrait) or right (landscape).
+function toA4(contentW: number, contentH: number, orientation: SiteOrientation): { w: number; h: number } {
+  if (orientation === "portrait") {
+    const w = Math.max(contentW, contentH / A4_RATIO);
+    return { w, h: w * A4_RATIO };
+  }
+  const h = Math.max(contentH, contentW / A4_RATIO);
+  return { w: h * A4_RATIO, h };
+}
+
 // How many columns for N devices in a group row
 function groupCols(n: number): number {
   if (n <= 2) return n;
@@ -188,6 +205,7 @@ function layoutAll(
     groupPositions: Array<{ gx: number; gy: number }>;
     siteW: number;
     siteH: number;
+    contentH: number;
     arpSectionH: number;
     arpCols: number;
     totalH: number;
@@ -203,7 +221,10 @@ function layoutAll(
     }
     const groups = [...osBuckets.values()].map((devices) => layoutGroup(devices, orientation));
     groups.sort((a, b) => b.devices.length - a.devices.length);
-    const { siteW, siteH, groupPositions } = layoutSite(groups, orientation);
+    const { siteW: contentW, siteH: contentH, groupPositions } = layoutSite(groups, orientation);
+    // Lock the managed-device box to A4 proportions; the device grid stays
+    // top-left and the box gains whitespace to reach the ratio.
+    const { w: siteW, h: siteH } = toA4(contentW, contentH, orientation);
 
     const siteArpDevices = arpDevicesBySite.get(site.id) ?? [];
     let arpSectionH = 0;
@@ -214,7 +235,12 @@ function layoutAll(
       arpSectionH = ARP_SECTION_LABEL_H + ARP_SECTION_PAD * 2 + arpRows * ARP_NODE_H + Math.max(0, arpRows - 1) * ARP_NODE_GAP_Y + GROUP_GAP;
     }
 
-    sitePreLayout.push({ site, orientation, groups, groupPositions, siteW, siteH, arpSectionH, arpCols, totalH: siteH + arpSectionH });
+    // Discovered devices are placed directly below the managed-device content (see
+    // relayoutArpNodes), not below the A4 box bottom. Row spacing must reserve the
+    // height relayoutArpNodes will actually produce, or boxes overlap the row below
+    // when discovered is shown. With discovered off, the box is the exact A4 height.
+    const totalH = arpSectionH > 0 ? Math.max(siteH, contentH + SITE_PAD + arpSectionH) : siteH;
+    sitePreLayout.push({ site, orientation, groups, groupPositions, siteW, siteH, contentH, arpSectionH, arpCols, totalH });
   }
 
   // Determine placement: try to fit all sites within viewW × viewH.
@@ -238,6 +264,10 @@ function layoutAll(
     }
     sitePositions.push({ x: curSiteX, y: curSiteY });
     curSiteX += pre.siteW + SITE_GAP;
+    // Place rows using the full site height (including the discovered/ARP section)
+    // so boxes never overlap the row below when discovered devices are shown. The
+    // viewport's zoom/pan is preserved separately (see skipAutoFitOnceRef in
+    // TopologyMap) so this reflow doesn't snap the user's view back to fit.
     siteRowH = Math.max(siteRowH, pre.totalH);
   }
 
@@ -272,7 +302,7 @@ function layoutAll(
   for (let si = 0; si < sitePreLayout.length; si++) {
     const pre = sitePreLayout[si];
     const pos = sitePositions[si];
-    const { site, groups, groupPositions, siteW, siteH, arpCols } = pre;
+    const { site, groups, groupPositions, siteW, contentH, arpCols } = pre;
 
     // All coordinates are in natural (unscaled) layout space.
     // The caller applies initialScale as a uniform SVG transform so that
@@ -329,7 +359,7 @@ function layoutAll(
     // Place ARP discovered devices below the managed device groups
     const siteArpDevices = arpDevicesBySite.get(site.id) ?? [];
     if (showArpDevices && siteArpDevices.length > 0) {
-      const arpStartY = siteY + siteH + GROUP_GAP;
+      const arpStartY = siteY + contentH + GROUP_GAP;
       const arpStartX = siteX + SITE_PAD + ARP_SECTION_PAD;
 
       siteArpDevices.forEach((ad, i) => {
@@ -444,28 +474,32 @@ function fitSitesToDeviceGroups(sites: SiteCluster[], nextGroups: DeviceGroup[])
     const x = minX - SITE_PAD;
     const y = minY - SITE_LABEL_H - SITE_PAD;
 
+    const contentW = Math.max(maxX + SITE_PAD - x, 160);
+    const contentH = Math.max(maxY + SITE_PAD - y, SITE_LABEL_H + SITE_PAD * 2);
+    const a4 = toA4(contentW, contentH, site.orientation);
+
     return {
       ...site,
       x,
       y,
-      width: Math.max(maxX + SITE_PAD - x, 160),
-      height: Math.max(maxY + SITE_PAD - y, SITE_LABEL_H + SITE_PAD * 2),
+      width: a4.w,
+      height: a4.h,
     };
   });
 }
 
 function getSiteContentMinSize(siteId: string, groups: DeviceGroup[], site?: SiteCluster): { width: number; height: number } {
   const siteGroups = groups.filter((group) => group.siteId === siteId);
+  const floorH = SITE_LABEL_H + SITE_PAD * 2;
   if (siteGroups.length === 0 || !site) {
-    return { width: 160, height: SITE_LABEL_H + SITE_PAD * 2 };
+    return { width: 160, height: floorH };
   }
 
-  const maxRight = Math.max(...siteGroups.map((group) => group.x + group.width));
-  const maxBottom = Math.max(...siteGroups.map((group) => group.y + group.height));
-  return {
-    width: Math.max(maxRight - site.x + SITE_PAD, 160),
-    height: Math.max(maxBottom - site.y + SITE_PAD, SITE_LABEL_H + SITE_PAD * 2),
-  };
+  // The narrowest the content can reflow to is a single device column — return that
+  // as the floor (NOT the current footprint) so a resize can pack the grid into
+  // fewer columns and the box can actually shrink. reflowSiteContents enforces the
+  // true content-fit for the chosen width and the A4 re-snap finalises the shape.
+  return { width: NODE_W + GROUP_PAD * 2 + SITE_PAD * 2, height: floorH };
 }
 
 function reflowSiteContents(
@@ -631,6 +665,106 @@ function relayoutArpNodes(
   return { sites: nextSites, arpNodes: placed };
 }
 
+// Grow each site box (never shrink) so it encloses all its device groups and
+// discovered boxes plus padding. Keeps the box's position/size when its content
+// already fits (so the A4 size is preserved); only expands when collision
+// separation has pushed a child past the current border.
+function fitSitesToContents(
+  sites: SiteCluster[],
+  groups: DeviceGroup[],
+  arpNodes: ArpDeviceLayoutNode[],
+): SiteCluster[] {
+  return sites.map((site) => {
+    const sg = groups.filter((g) => g.siteId === site.id);
+    const sa = arpNodes.filter((a) => a.siteId === site.id);
+    if (sg.length === 0 && sa.length === 0) return site;
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const g of sg) {
+      minX = Math.min(minX, g.x); minY = Math.min(minY, g.y);
+      maxX = Math.max(maxX, g.x + g.width); maxY = Math.max(maxY, g.y + g.height);
+    }
+    for (const a of sa) {
+      minX = Math.min(minX, a.x - ARP_NODE_W / 2); minY = Math.min(minY, a.y - ARP_NODE_H / 2);
+      maxX = Math.max(maxX, a.x + ARP_NODE_W / 2); maxY = Math.max(maxY, a.y + ARP_NODE_H / 2);
+    }
+
+    const x = Math.min(site.x, minX - SITE_PAD);
+    const y = Math.min(site.y, minY - SITE_LABEL_H - SITE_PAD);
+    const right = Math.max(site.x + site.width, maxX + SITE_PAD);
+    const bottom = Math.max(site.y + site.height, maxY + SITE_PAD);
+    return { ...site, x, y, width: right - x, height: bottom - y };
+  });
+}
+
+interface CollisionAnchor {
+  /** Site whose box must not move (the one being dragged/resized). */
+  site?: string;
+  /** Device node whose box must not move (the one being dragged). */
+  node?: string;
+}
+
+// Push overlapping boxes apart with minimal displacement, preserving the overall
+// arrangement. Two scopes: device nodes within each site, then site boxes against
+// each other (carrying their contents along). Idempotent — a non-overlapping layout
+// is returned unchanged via the fast-path guard.
+function resolveCollisions(
+  sites: SiteCluster[],
+  groups: DeviceGroup[],
+  nodes: LayoutNode[],
+  arpNodes: ArpDeviceLayoutNode[],
+  anchor?: CollisionAnchor,
+): { sites: SiteCluster[]; groups: DeviceGroup[]; nodes: LayoutNode[]; arpNodes: ArpDeviceLayoutNode[] } {
+  let S = sites, G = groups, N = nodes, A = arpNodes;
+
+  const nodesBySite = new Map<string, LayoutNode[]>();
+  for (const n of N) {
+    if (!nodesBySite.has(n.siteId)) nodesBySite.set(n.siteId, []);
+    nodesBySite.get(n.siteId)!.push(n);
+  }
+  const nodeBox = (n: LayoutNode) => ({ id: n.hostname, x: n.x - NODE_W / 2, y: n.y - NODE_H / 2, width: NODE_W, height: NODE_H });
+
+  // Intra-site device overlaps only happen after a manual device drop; detect cheaply.
+  let intraOverlap = false;
+  for (const list of nodesBySite.values()) {
+    if (list.length > 1 && anyOverlap(list.map(nodeBox))) { intraOverlap = true; break; }
+  }
+  const siteBox = (s: SiteCluster) => ({ id: s.id, x: s.x, y: s.y, width: s.width, height: s.height });
+  if (!intraOverlap && !anyOverlap(S.map(siteBox), SITE_GAP)) {
+    return { sites: S, groups: G, nodes: N, arpNodes: A }; // nothing to resolve
+  }
+
+  // 1. Separate overlapping device nodes within each site, then refit borders, the
+  //    discovered section, and grow the site to enclose the result.
+  if (intraOverlap) {
+    const nodeDisp = new Map<string, { dx: number; dy: number }>();
+    for (const list of nodesBySite.values()) {
+      if (list.length < 2) continue;
+      const disp = separateBoxes(list.map(nodeBox), { margin: NODE_GAP_X, anchorId: anchor?.node });
+      for (const [id, d] of disp) nodeDisp.set(id, d);
+    }
+    if (nodeDisp.size > 0) {
+      N = N.map((n) => { const d = nodeDisp.get(n.hostname); return d ? { ...n, x: n.x + d.dx, y: n.y + d.dy } : n; });
+      G = fitDeviceGroupsToNodes(G, N);
+      const re = relayoutArpNodes(S, G, A);
+      S = fitSitesToContents(re.sites, G, re.arpNodes);
+      A = re.arpNodes;
+    }
+  }
+
+  // 2. Separate site boxes; translate each site's contents by the same vector.
+  for (let iter = 0; iter < 8; iter++) {
+    const disp = separateBoxes(S.map(siteBox), { margin: SITE_GAP, anchorId: anchor?.site });
+    if (disp.size === 0) break;
+    S = S.map((s) => { const d = disp.get(s.id); return d ? { ...s, x: s.x + d.dx, y: s.y + d.dy } : s; });
+    G = G.map((g) => { const d = disp.get(g.siteId); return d ? { ...g, x: g.x + d.dx, y: g.y + d.dy } : g; });
+    N = N.map((n) => { const d = disp.get(n.siteId); return d ? { ...n, x: n.x + d.dx, y: n.y + d.dy } : n; });
+    A = A.map((a) => { const d = disp.get(a.siteId); return d ? { ...a, x: a.x + d.dx, y: a.y + d.dy } : a; });
+  }
+
+  return { sites: S, groups: G, nodes: N, arpNodes: A };
+}
+
 // Identifies the structural shape of the topology (which sites/devices/arp devices
 // exist) plus the inputs that affect the generated layout. When this is unchanged
 // across a refetch, we keep the user's manual positions instead of regenerating.
@@ -719,30 +853,39 @@ export function useForceLayout(
     const result = layoutAll(effectiveData, containerWidth, siteOrientations, showArpDevices, containerHeight, topReserve);
     // Overlay saved positions on top of freshly-computed ones so manual drags
     // and resizes from a previous session are restored after reload.
-    const restoredSites = persist.applySitePositions(result.sites);
     const restoredNodes = persist.applyNodePositions(result.nodes);
-    // Links and device-group borders are derived from node positions. The freshly
-    // built links/groups still point at the pre-restore node coordinates, so rebind
-    // links to the restored nodes and refit the group borders — otherwise overlay
-    // lines and category boxes snap back to their original spots on refresh.
-    const restoredNodeMap = new Map(restoredNodes.map((n) => [n.hostname, n]));
+    const restoredGroups = fitDeviceGroupsToNodes(result.deviceGroups, restoredNodes);
+    // Size each site elastically to its current managed content (A4 of the restored
+    // device groups), discarding any stale persisted size. This is what lets a box
+    // that grew to fit discovered devices SHRINK back to the smallest size enclosing
+    // the device boxes once discovered devices are toggled off. Position follows the
+    // content (which moves with the user's drags), so manual placement is preserved.
+    const restoredSites = fitSitesToDeviceGroups(persist.applySitePositions(result.sites), restoredGroups);
+    // ARP discovered-device boxes are placed relative to the restored site/group
+    // positions and the site grows (again) to enclose them while they're shown.
+    const arp = relayoutArpNodes(restoredSites, restoredGroups, result.arpDeviceNodes);
+
+    // Dynamically push apart any boxes the saved layout would render overlapping
+    // (e.g. a manual layout that can't accommodate the discovered-devices section),
+    // preserving the user's arrangement instead of discarding it.
+    const resolved = resolveCollisions(arp.sites, restoredGroups, restoredNodes, arp.arpNodes);
+
+    // Links and device-group borders are derived from node positions, so rebind the
+    // links to the resolved node coordinates — otherwise overlay lines snap back.
+    const resolvedNodeMap = new Map(resolved.nodes.map((n) => [n.hostname, n]));
     const rebind = <T extends { source: LayoutNode; target: LayoutNode }>(link: T): T => ({
       ...link,
-      source: restoredNodeMap.get(link.source.hostname) ?? link.source,
-      target: restoredNodeMap.get(link.target.hostname) ?? link.target,
+      source: resolvedNodeMap.get(link.source.hostname) ?? link.source,
+      target: resolvedNodeMap.get(link.target.hostname) ?? link.target,
     });
-    const restoredGroups = fitDeviceGroupsToNodes(result.deviceGroups, restoredNodes);
-    // ARP discovered-device boxes are placed relative to the restored site/group
-    // positions and the site grows to enclose them. They were set straight from
-    // the fresh layout (original site coords), so they snapped back on refresh.
-    const arp = relayoutArpNodes(restoredSites, restoredGroups, result.arpDeviceNodes);
-    setSites(arp.sites);
-    setNodes(restoredNodes);
+
+    setSites(resolved.sites);
+    setNodes(resolved.nodes);
     setLinks(result.links.map(rebind));
     setNeighborLinks(result.neighborLinks.map(rebind));
     setArpLinks(result.arpLinks.map(rebind));
-    setArpDeviceNodes(arp.arpNodes);
-    setDeviceGroups(restoredGroups);
+    setArpDeviceNodes(resolved.arpNodes);
+    setDeviceGroups(resolved.groups);
     setInitialScale(result.initialScale);
   }, [data, containerWidth, containerHeight, siteOrientations, showArpDevices, topReserve, isDragging]);
 
@@ -769,30 +912,36 @@ export function useForceLayout(
       persist.saveSiteOrientation(siteId, next[siteId]);
       return next;
     });
+    // Flip a manually-resized box's A4 dimensions to the new orientation so it stays
+    // locked to the ratio (no-op for sites still using the auto A4 layout).
+    persist.swapSiteSize(siteId);
   }, []);
 
   const moveSite = useCallback((siteId: string, dx: number, dy: number) => {
-    setSites((prev) => {
-      const next = prev.map((site) =>
-        site.id === siteId ? { ...site, x: site.x + dx, y: site.y + dy } : site,
-      );
-      persist.saveSitePositions(next.filter((s) => s.id === siteId));
-      return next;
-    });
-    setDeviceGroups((prev) => prev.map((group) => (
-      group.siteId === siteId ? { ...group, x: group.x + dx, y: group.y + dy } : group
-    )));
-    setArpDeviceNodes((prev) => prev.map((ad) => (
-      ad.siteId === siteId ? { ...ad, x: ad.x + dx, y: ad.y + dy } : ad
-    )));
-    setNodes((prev) => {
-      const nextNodes = prev.map((node) => (
-        node.siteId === siteId ? { ...node, x: node.x + dx, y: node.y + dy } : node
-      ));
-      persist.saveNodePositions(nextNodes.filter((n) => n.siteId === siteId));
-      relinkNodes(nextNodes);
-      return nextNodes;
-    });
+    const movedSites = sitesRef.current.map((s) => (
+      s.id === siteId ? { ...s, x: s.x + dx, y: s.y + dy } : s
+    ));
+    const movedGroups = deviceGroupsRef.current.map((g) => (
+      g.siteId === siteId ? { ...g, x: g.x + dx, y: g.y + dy } : g
+    ));
+    const movedArp = arpDeviceNodesRef.current.map((a) => (
+      a.siteId === siteId ? { ...a, x: a.x + dx, y: a.y + dy } : a
+    ));
+    const movedNodes = nodesRef.current.map((n) => (
+      n.siteId === siteId ? { ...n, x: n.x + dx, y: n.y + dy } : n
+    ));
+    // Push the other sites out of the dragged site's way (it stays under the cursor).
+    const r = resolveCollisions(movedSites, movedGroups, movedNodes, movedArp, { site: siteId });
+
+    // Persist only the dragged site; neighbours move in-memory until the user drags
+    // them, so the saved layout stays the user's own arrangement.
+    persist.saveSitePositions(r.sites.filter((s) => s.id === siteId));
+    persist.saveNodePositions(r.nodes.filter((n) => n.siteId === siteId));
+    setSites(r.sites);
+    setDeviceGroups(r.groups);
+    setArpDeviceNodes(r.arpNodes);
+    setNodes(r.nodes);
+    relinkNodes(r.nodes);
   }, [relinkNodes]);
 
   const moveDevice = useCallback((hostname: string, dx: number, dy: number) => {
@@ -802,14 +951,17 @@ export function useForceLayout(
     const nextGroups = fitDeviceGroupsToNodes(deviceGroupsRef.current, nextNodes);
     const fittedSites = fitSitesToDeviceGroups(sitesRef.current, nextGroups);
     const arp = relayoutArpNodes(fittedSites, nextGroups, arpDeviceNodesRef.current);
+    // Push sibling devices/discovered (and any collided sites) out of the dragged
+    // device's way; the dragged node stays under the cursor.
+    const r = resolveCollisions(arp.sites, nextGroups, nextNodes, arp.arpNodes, { node: hostname });
 
-    persist.saveNodePositions(nextNodes.filter((n) => n.hostname === hostname));
-    persist.saveSitePositions(arp.sites);
-    setNodes(nextNodes);
-    setDeviceGroups(nextGroups);
-    setSites(arp.sites);
-    setArpDeviceNodes(arp.arpNodes);
-    relinkNodes(nextNodes);
+    persist.saveNodePositions(r.nodes.filter((n) => n.hostname === hostname));
+    persist.saveSitePositions(r.sites);
+    setNodes(r.nodes);
+    setDeviceGroups(r.groups);
+    setSites(r.sites);
+    setArpDeviceNodes(r.arpNodes);
+    relinkNodes(r.nodes);
   }, [relinkNodes]);
 
   const resizeSite = useCallback((siteId: string, width: number, height: number) => {
@@ -817,24 +969,32 @@ export function useForceLayout(
     if (!site) return;
 
     const minSize = getSiteContentMinSize(siteId, deviceGroupsRef.current, site);
+    // Lock the box to A4: build the smallest A4 box (for this orientation) that
+    // contains both the drag target and the content minimum, reflow into it, then
+    // re-snap in case the reflow had to grow the box to fit content.
+    const want = toA4(Math.max(width, minSize.width), Math.max(height, minSize.height), site.orientation);
     const result = reflowSiteContents(
       site,
-      Math.max(width, minSize.width),
-      Math.max(height, minSize.height),
+      want.w,
+      want.h,
       nodesRef.current,
       deviceGroupsRef.current,
     );
+    const finalA4 = toA4(result.site.width, result.site.height, site.orientation);
+    const a4Site = { ...result.site, width: finalA4.w, height: finalA4.h };
 
-    const resizedSites = sitesRef.current.map((candidate) => candidate.id === siteId ? result.site : candidate);
+    const resizedSites = sitesRef.current.map((candidate) => candidate.id === siteId ? a4Site : candidate);
     const arp = relayoutArpNodes(resizedSites, result.groups, arpDeviceNodesRef.current);
+    // Push neighbours out of the way of the enlarged box (it stays anchored).
+    const r = resolveCollisions(arp.sites, result.groups, result.nodes, arp.arpNodes, { site: siteId });
 
-    persist.saveSitePositions(arp.sites.filter((s) => s.id === siteId));
-    persist.saveNodePositions(result.nodes.filter((n) => n.siteId === siteId));
-    setSites(arp.sites);
-    setDeviceGroups(result.groups);
-    setNodes(result.nodes);
-    setArpDeviceNodes(arp.arpNodes);
-    relinkNodes(result.nodes);
+    persist.saveSitePositions(r.sites.filter((s) => s.id === siteId));
+    persist.saveNodePositions(r.nodes.filter((n) => n.siteId === siteId));
+    setSites(r.sites);
+    setDeviceGroups(r.groups);
+    setNodes(r.nodes);
+    setArpDeviceNodes(r.arpNodes);
+    relinkNodes(r.nodes);
   }, [relinkNodes]);
 
   return {

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -488,103 +488,20 @@ function fitSitesToDeviceGroups(sites: SiteCluster[], nextGroups: DeviceGroup[])
   });
 }
 
-function reflowSiteContents(
-  site: SiteCluster,
-  nextWidth: number,
-  nextHeight: number,
-  currentNodes: LayoutNode[],
-  currentGroups: DeviceGroup[],
-): { site: SiteCluster; nodes: LayoutNode[]; groups: DeviceGroup[] } {
-  const siteGroups = currentGroups
-    .filter((group) => group.siteId === site.id)
-    .sort((a, b) => {
-      const countA = currentNodes.filter((node) => node.siteId === a.siteId && node.os === a.os).length;
-      const countB = currentNodes.filter((node) => node.siteId === b.siteId && node.os === b.os).length;
-      return countB - countA;
-    });
+// Smallest box (anchored at the site's top-left) that tightly encloses the site's
+// managed device groups plus padding — i.e. the A4 whitespace removed. Used by
+// manual resize: the box may shrink down to this, never below it, so devices keep
+// their positions and gaps and can never end up outside the box.
+function tightSiteSize(site: SiteCluster, siteGroups: DeviceGroup[]): { width: number; height: number } {
+  const floorW = NODE_W + GROUP_PAD * 2 + SITE_PAD * 2;
+  const floorH = SITE_LABEL_H + SITE_PAD * 2;
+  if (siteGroups.length === 0) return { width: floorW, height: floorH };
 
-  if (siteGroups.length === 0) {
-    return {
-      site: { ...site, width: Math.max(nextWidth, 160), height: Math.max(nextHeight, SITE_LABEL_H + SITE_PAD * 2) },
-      nodes: currentNodes,
-      groups: currentGroups,
-    };
-  }
-
-  const maxContentW = Math.max(nextWidth - SITE_PAD * 2, NODE_W + GROUP_PAD * 2);
-  const updatedNodes = [...currentNodes];
-  const updatedGroupMap = new Map<string, DeviceGroup>();
-
-  let curX = site.x + SITE_PAD;
-  let curY = site.y + SITE_LABEL_H + SITE_PAD;
-  let rowH = 0;
-  let maxRight = site.x + SITE_PAD;
-  let maxBottom = site.y + SITE_LABEL_H + SITE_PAD;
-
-  for (const group of siteGroups) {
-    const groupNodes = updatedNodes
-      .filter((node) => node.siteId === site.id && node.os === group.os)
-      .sort((a, b) => a.hostname.localeCompare(b.hostname));
-
-    if (groupNodes.length === 0) continue;
-
-    const maxCols = Math.max(1, Math.floor((maxContentW - GROUP_PAD * 2 + NODE_GAP_X) / (NODE_W + NODE_GAP_X)));
-    const lCols = groupCols(groupNodes.length);
-    const lRows = Math.ceil(groupNodes.length / lCols);
-    const cols = site.orientation === "portrait"
-      ? Math.min(lRows, maxCols)
-      : Math.min(groupNodes.length, maxCols);
-    const rows = Math.ceil(groupNodes.length / cols);
-    const baseW = GROUP_PAD * 2 + cols * NODE_W;
-    const availableGapX = maxContentW - baseW;
-    const gapX = cols > 1 ? Math.max(NODE_GAP_X, availableGapX / (cols - 1)) : 0;
-    const groupW = Math.min(maxContentW, GROUP_PAD * 2 + cols * NODE_W + Math.max(0, cols - 1) * gapX);
-    const groupH = GROUP_LABEL_H + GROUP_PAD * 2 + rows * NODE_H + Math.max(0, rows - 1) * NODE_GAP_Y;
-
-    if (curX + groupW > site.x + nextWidth - SITE_PAD && curX > site.x + SITE_PAD) {
-      curX = site.x + SITE_PAD;
-      curY += rowH + GROUP_GAP;
-      rowH = 0;
-    }
-
-    updatedGroupMap.set(`${group.siteId}:${group.os}`, {
-      ...group,
-      x: curX,
-      y: curY,
-      width: groupW,
-      height: groupH,
-    });
-
-    groupNodes.forEach((node, index) => {
-      const nodeIndex = updatedNodes.findIndex((candidate) => candidate.hostname === node.hostname);
-      if (nodeIndex < 0) return;
-      const col = index % cols;
-      const row = Math.floor(index / cols);
-      updatedNodes[nodeIndex] = {
-        ...updatedNodes[nodeIndex],
-        x: curX + GROUP_PAD + NODE_W / 2 + col * (NODE_W + gapX),
-        y: curY + GROUP_LABEL_H + GROUP_PAD + NODE_H / 2 + row * (NODE_H + NODE_GAP_Y),
-      };
-    });
-
-    maxRight = Math.max(maxRight, curX + groupW);
-    maxBottom = Math.max(maxBottom, curY + groupH);
-    curX += groupW + GROUP_GAP;
-    rowH = Math.max(rowH, groupH);
-  }
-
-  const updatedGroups = currentGroups.map((group) => updatedGroupMap.get(`${group.siteId}:${group.os}`) ?? group);
-  const minWidth = maxRight - site.x + SITE_PAD;
-  const minHeight = maxBottom - site.y + SITE_PAD;
-
+  const maxRight = Math.max(...siteGroups.map((g) => g.x + g.width));
+  const maxBottom = Math.max(...siteGroups.map((g) => g.y + g.height));
   return {
-    site: {
-      ...site,
-      width: Math.max(nextWidth, minWidth, 160),
-      height: Math.max(nextHeight, minHeight, SITE_LABEL_H + SITE_PAD * 2),
-    },
-    nodes: updatedNodes,
-    groups: updatedGroups,
+    width: Math.max(maxRight + SITE_PAD - site.x, floorW),
+    height: Math.max(maxBottom + SITE_PAD - site.y, floorH),
   };
 }
 
@@ -951,31 +868,28 @@ export function useForceLayout(
     const site = sitesRef.current.find((candidate) => candidate.id === siteId);
     if (!site) return;
 
-    // Free resize: the box becomes the dragged size (floored so content isn't
-    // clipped), with width/height independent — no A4 lock. Content reflows to fit.
-    const floorW = NODE_W + GROUP_PAD * 2 + SITE_PAD * 2;
-    const floorH = SITE_LABEL_H + SITE_PAD * 2;
-    const result = reflowSiteContents(
-      site,
-      Math.max(width, floorW),
-      Math.max(height, floorH),
-      nodesRef.current,
-      deviceGroupsRef.current,
-    );
-    // reflowSiteContents returns max(dragged, content-fit), so the box never clips
-    // its devices. This managed size is what gets persisted (without any discovered
-    // section, which is re-added elastically below).
-    const managedSite = result.site;
+    // Shrink-to-fit, no reflow: the box wraps its existing managed device grid
+    // tightly (removing the A4 whitespace). Devices never move and their gaps never
+    // change. The dragged size is clamped UP to the content's tight bounds, so the
+    // box can only ever remove empty space — never clip a device or push one outside.
+    const siteGroups = deviceGroupsRef.current.filter((g) => g.siteId === siteId);
+    const tight = tightSiteSize(site, siteGroups);
+    const managedSite: SiteCluster = {
+      ...site,
+      width: Math.max(width, tight.width),
+      height: Math.max(height, tight.height),
+    };
 
     const resizedSites = sitesRef.current.map((candidate) => candidate.id === siteId ? managedSite : candidate);
-    const arp = relayoutArpNodes(resizedSites, result.groups, arpDeviceNodesRef.current);
+    // Re-add the discovered section below the (unchanged) managed content; the box
+    // grows again elastically to enclose it while discovered devices are shown.
+    const arp = relayoutArpNodes(resizedSites, deviceGroupsRef.current, arpDeviceNodesRef.current);
     // Push neighbours out of the way of the resized box (it stays anchored).
-    const r = resolveCollisions(arp.sites, result.groups, result.nodes, arp.arpNodes, { site: siteId });
+    const r = resolveCollisions(arp.sites, deviceGroupsRef.current, nodesRef.current, arp.arpNodes, { site: siteId });
 
     // Persist the managed (pre-discovered) size so it sticks across refreshes and
     // discovered toggles; the elastic layout re-adds the discovered section on top.
     persist.saveSitePositions([managedSite]);
-    persist.saveNodePositions(r.nodes.filter((n) => n.siteId === siteId));
     setSites(r.sites);
     setDeviceGroups(r.groups);
     setNodes(r.nodes);

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -488,20 +488,6 @@ function fitSitesToDeviceGroups(sites: SiteCluster[], nextGroups: DeviceGroup[])
   });
 }
 
-function getSiteContentMinSize(siteId: string, groups: DeviceGroup[], site?: SiteCluster): { width: number; height: number } {
-  const siteGroups = groups.filter((group) => group.siteId === siteId);
-  const floorH = SITE_LABEL_H + SITE_PAD * 2;
-  if (siteGroups.length === 0 || !site) {
-    return { width: 160, height: floorH };
-  }
-
-  // The narrowest the content can reflow to is a single device column — return that
-  // as the floor (NOT the current footprint) so a resize can pack the grid into
-  // fewer columns and the box can actually shrink. reflowSiteContents enforces the
-  // true content-fit for the chosen width and the A4 re-snap finalises the shape.
-  return { width: NODE_W + GROUP_PAD * 2 + SITE_PAD * 2, height: floorH };
-}
-
 function reflowSiteContents(
   site: SiteCluster,
   nextWidth: number,
@@ -856,11 +842,10 @@ export function useForceLayout(
     const restoredNodes = persist.applyNodePositions(result.nodes);
     const restoredGroups = fitDeviceGroupsToNodes(result.deviceGroups, restoredNodes);
     // Size each site elastically to its current managed content (A4 of the restored
-    // device groups), discarding any stale persisted size. This is what lets a box
-    // that grew to fit discovered devices SHRINK back to the smallest size enclosing
-    // the device boxes once discovered devices are toggled off. Position follows the
-    // content (which moves with the user's drags), so manual placement is preserved.
-    const restoredSites = fitSitesToDeviceGroups(persist.applySitePositions(result.sites), restoredGroups);
+    // device groups) so a box that grew for discovered devices shrinks back once they
+    // are toggled off; then apply any manually-resized SIZE on top (free, non-A4) so a
+    // user's resize sticks. Position follows the content, so placement is preserved.
+    const restoredSites = persist.applySitePositions(fitSitesToDeviceGroups(result.sites, restoredGroups));
     // ARP discovered-device boxes are placed relative to the restored site/group
     // positions and the site grows (again) to enclose them while they're shown.
     const arp = relayoutArpNodes(restoredSites, restoredGroups, result.arpDeviceNodes);
@@ -912,8 +897,8 @@ export function useForceLayout(
       persist.saveSiteOrientation(siteId, next[siteId]);
       return next;
     });
-    // Flip a manually-resized box's A4 dimensions to the new orientation so it stays
-    // locked to the ratio (no-op for sites still using the auto A4 layout).
+    // Rotate a manually-resized box's dimensions with the orientation flip (no-op for
+    // sites still using the auto elastic layout).
     persist.swapSiteSize(siteId);
   }, []);
 
@@ -933,9 +918,8 @@ export function useForceLayout(
     // Push the other sites out of the dragged site's way (it stays under the cursor).
     const r = resolveCollisions(movedSites, movedGroups, movedNodes, movedArp, { site: siteId });
 
-    // Persist only the dragged site; neighbours move in-memory until the user drags
-    // them, so the saved layout stays the user's own arrangement.
-    persist.saveSitePositions(r.sites.filter((s) => s.id === siteId));
+    // Persist the dragged site's node positions only — the box position is derived
+    // from its content, so this preserves placement without pinning the box size.
     persist.saveNodePositions(r.nodes.filter((n) => n.siteId === siteId));
     setSites(r.sites);
     setDeviceGroups(r.groups);
@@ -956,7 +940,6 @@ export function useForceLayout(
     const r = resolveCollisions(arp.sites, nextGroups, nextNodes, arp.arpNodes, { node: hostname });
 
     persist.saveNodePositions(r.nodes.filter((n) => n.hostname === hostname));
-    persist.saveSitePositions(r.sites);
     setNodes(r.nodes);
     setDeviceGroups(r.groups);
     setSites(r.sites);
@@ -968,27 +951,30 @@ export function useForceLayout(
     const site = sitesRef.current.find((candidate) => candidate.id === siteId);
     if (!site) return;
 
-    const minSize = getSiteContentMinSize(siteId, deviceGroupsRef.current, site);
-    // Lock the box to A4: build the smallest A4 box (for this orientation) that
-    // contains both the drag target and the content minimum, reflow into it, then
-    // re-snap in case the reflow had to grow the box to fit content.
-    const want = toA4(Math.max(width, minSize.width), Math.max(height, minSize.height), site.orientation);
+    // Free resize: the box becomes the dragged size (floored so content isn't
+    // clipped), with width/height independent — no A4 lock. Content reflows to fit.
+    const floorW = NODE_W + GROUP_PAD * 2 + SITE_PAD * 2;
+    const floorH = SITE_LABEL_H + SITE_PAD * 2;
     const result = reflowSiteContents(
       site,
-      want.w,
-      want.h,
+      Math.max(width, floorW),
+      Math.max(height, floorH),
       nodesRef.current,
       deviceGroupsRef.current,
     );
-    const finalA4 = toA4(result.site.width, result.site.height, site.orientation);
-    const a4Site = { ...result.site, width: finalA4.w, height: finalA4.h };
+    // reflowSiteContents returns max(dragged, content-fit), so the box never clips
+    // its devices. This managed size is what gets persisted (without any discovered
+    // section, which is re-added elastically below).
+    const managedSite = result.site;
 
-    const resizedSites = sitesRef.current.map((candidate) => candidate.id === siteId ? a4Site : candidate);
+    const resizedSites = sitesRef.current.map((candidate) => candidate.id === siteId ? managedSite : candidate);
     const arp = relayoutArpNodes(resizedSites, result.groups, arpDeviceNodesRef.current);
-    // Push neighbours out of the way of the enlarged box (it stays anchored).
+    // Push neighbours out of the way of the resized box (it stays anchored).
     const r = resolveCollisions(arp.sites, result.groups, result.nodes, arp.arpNodes, { site: siteId });
 
-    persist.saveSitePositions(r.sites.filter((s) => s.id === siteId));
+    // Persist the managed (pre-discovered) size so it sticks across refreshes and
+    // discovered toggles; the elastic layout re-adds the discovered section on top.
+    persist.saveSitePositions([managedSite]);
     persist.saveNodePositions(r.nodes.filter((n) => n.siteId === siteId));
     setSites(r.sites);
     setDeviceGroups(r.groups);

--- a/frontend/src/hooks/usePersistedLayout.ts
+++ b/frontend/src/hooks/usePersistedLayout.ts
@@ -100,6 +100,17 @@ export function usePersistedLayout() {
     writeStorage(cacheRef.current);
   }, []);
 
+  // Swap a persisted box's width/height (no-op if the site has no saved size).
+  // An A4-portrait box (w, w·√2) becomes A4-landscape (w·√2, w) and vice-versa,
+  // so a manually-resized box stays locked to the ratio across an orientation flip.
+  const swapSiteSize = useCallback((siteId: string) => {
+    const p = cacheRef.current.sitePositions[siteId];
+    if (!p) return;
+    const next = { ...cacheRef.current.sitePositions, [siteId]: { ...p, width: p.height, height: p.width } };
+    cacheRef.current = { ...cacheRef.current, sitePositions: next };
+    writeStorage(cacheRef.current);
+  }, []);
+
   // Persist a single site orientation change.
   const saveSiteOrientation = useCallback((siteId: string, orientation: SiteOrientation) => {
     const next = { ...cacheRef.current.siteOrientations, [siteId]: orientation };
@@ -120,6 +131,7 @@ export function usePersistedLayout() {
     saveSitePositions,
     saveNodePositions,
     saveSiteOrientation,
+    swapSiteSize,
     clearPersistedLayout,
   };
 }

--- a/frontend/src/hooks/usePersistedLayout.ts
+++ b/frontend/src/hooks/usePersistedLayout.ts
@@ -56,12 +56,14 @@ export function usePersistedLayout() {
 
   // Apply saved positions onto a freshly-computed site array.
   // Sites whose IDs aren't in storage keep their computed positions.
+  // Restore only the manually-resized SIZE; position is always derived from the
+  // (content-driven) auto-layout so site boxes stay elastic and follow their devices.
   const applySitePositions = useCallback((sites: SiteCluster[]): SiteCluster[] => {
     const saved = cacheRef.current.sitePositions;
     return sites.map((site) => {
       const p = saved[site.id];
       if (!p) return site;
-      return { ...site, x: p.x, y: p.y, width: p.width, height: p.height };
+      return { ...site, width: p.width, height: p.height };
     });
   }, []);
 


### PR DESCRIPTION
## Summary

Overhaul of the topology map's site-layout engine (`useForceLayout`) plus supporting UI tweaks.

- **Overlay button legend** — drop the standalone color-swatch line; the bold subnet/mask text is now color-coded and doubles as the legend.
- **Viewport stability** — toggling *Discovered* devices and flipping a site's orientation no longer snap the viewport back to fit; zoom/pan is preserved (`skipAutoFitOnceRef`).
- **A4-locked site boxes** — site boxes are locked to A4 (√2:1) proportions for both portrait and landscape, including manual resize. Discovered devices extend below the managed-device box.
- **Elastic boundaries** — each box is sized to its current content every layout pass, so a box that grew for discovered devices shrinks back when they're toggled off, and a stale oversized saved size is ignored.
- **Dynamic collision separation** — overlapping site/device/discovered boxes are pushed apart with minimal displacement (MTV relaxation in `hooks/layout/separation.ts`), preserving the user's arrangement, with the dragged box anchored. Replaces the prior "discard the saved layout on overlap" fallback.
- **Resize fix** — the resize floor is lowered to a single device column so a box can reflow narrower and actually shrink.

Adds a design spec and implementation plan under `docs/superpowers/`.

## Verification

Verified in a headless browser (CDP) against the running app:
- Discovered toggle / orientation flip: zoom/pan preserved, 0 box overlaps.
- Elastic: box heights grow on discovered-on and return exactly to baseline on discovered-off; stale oversized saved size ignored.
- Collision separation: an injected overlapping saved layout separates to 0 overlaps, stays near the user's location (not regenerated), and is idempotent across reloads.

⚠️ **Not yet confirmed end-to-end:** the manual resize-shrink fix — the code change is in, but the headless drag-simulation didn't register the resize in the test harness. Worth a manual click-drag check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)