### PR TITLE
feat(search): include overlay/tunnel IPs in device search

### DIFF
--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -253,6 +253,7 @@ export function TopologyMap({ data, sse }: Props) {
           dev.ip?.includes(qLower) ||
           dev.lanIp?.includes(qLower) ||
           dev.ips?.some((ip) => ip.includes(qLower)) ||
+          dev.overlayPorts?.some((p) => p.ip?.includes(qLower)) ||
           (looksLikeMac && dev.macs?.some((m) => normalizeMacSearch(m).includes(qMac)))
         ) {
           matches.push(dev.hostname);


### PR DESCRIPTION
## Summary
- Search previously only matched against LAN IPs (`findDeviceIps` explicitly excludes overlay addresses)
- Added `dev.overlayPorts` IPs (ZeroTier, WireGuard, etc.) to the search matcher so devices are findable by any of their IP addresses — local, overlay, or tunnel

## Test plan
- [x] Search for an overlay IP (e.g. ZeroTier `10.x.x.x`) and verify the device highlights
- [x] Search for a LAN IP and verify it still works as before
- [x] Search by hostname, sysName, and MAC to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)