### PR TITLE
feat: minor features — display name, ARP LAN IPs, popover UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,14 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Build & Verify
+
+**The Docker build is the source of truth.**
+
+- Always verify changes with `docker-compose up -d --build` — not bare `tsc` or `npm run build`.
+- The containerized build is the real pipeline. Local toolchain checks can miss issues (different Node version, missing deps, layer caching).
+- Do not report work as done until the Docker build succeeds and the container starts.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Build & Verify
+
+**The Docker build is the source of truth.**
+
+- Always verify changes with `docker-compose up -d --build` — not bare `tsc` or `npm run build`.
+- The containerized build is the real pipeline. Local toolchain checks can miss issues (different Node version, missing deps, layer caching).
+- Do not report work as done until the Docker build succeeds and the container starts.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -150,18 +150,18 @@ export async function pollPortsAndIps() {
 
   for (const device of devices) {
     if (device.status !== 1) continue; // skip down devices
-    try {
-      const [ports, ips] = await Promise.all([
-        fetchDevicePorts(device.hostname),
-        fetchDeviceIps(device.hostname),
-      ]);
-      allPorts.set(device.hostname, ports);
-      allIps.set(device.hostname, ips);
-      cache.set(`ports:${device.hostname}`, ports, TTL.PORTS);
-      cache.set(`ips:${device.hostname}`, ips, TTL.DEVICE_IPS);
-    } catch (e) {
-      console.warn(`[poller] Failed to fetch ports/ips for ${device.hostname}:`, e);
-    }
+    const [portsResult, ipsResult] = await Promise.allSettled([
+      fetchDevicePorts(device.hostname),
+      fetchDeviceIps(device.hostname),
+    ]);
+    const ports = portsResult.status === "fulfilled" ? portsResult.value : [];
+    const ips = ipsResult.status === "fulfilled" ? ipsResult.value : [];
+    if (portsResult.status === "rejected") console.warn(`[poller] Failed to fetch ports for ${device.hostname}:`, portsResult.reason);
+    if (ipsResult.status === "rejected") console.warn(`[poller] Failed to fetch ips for ${device.hostname}:`, ipsResult.reason);
+    allPorts.set(device.hostname, ports);
+    allIps.set(device.hostname, ips);
+    cache.set(`ports:${device.hostname}`, ports, TTL.PORTS);
+    cache.set(`ips:${device.hostname}`, ips, TTL.DEVICE_IPS);
     await delay(STAGGER_MS);
   }
 
@@ -234,6 +234,21 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
       if (name) portIdToIfName.set(p.port_id, name);
       const mac = normalizeMac(p.ifPhysAddress ?? "");
       if (mac && mac.length === 12 && mac !== "000000000000") portIdToMac.set(p.port_id, mac);
+    }
+  }
+
+  // MAC → hostname for managed devices (from interface MACs), used for
+  // MAC-based ARP link matching when IP-based matching misses (e.g. device
+  // whose IP endpoint 404s but whose interface MACs appear in other ARP tables).
+  const macToHostname = new Map<string, string>();
+  for (const d of devices) {
+    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    if (!ports) continue;
+    for (const p of ports) {
+      const mac = normalizeMac(p.ifPhysAddress ?? "");
+      if (mac && mac.length === 12 && mac !== "000000000000") {
+        macToHostname.set(mac, d.hostname);
+      }
     }
   }
 
@@ -346,6 +361,41 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
     // fall through with whatever we collected per-IP
   }
 
+  // Second pass: create ARP links via MAC matching for managed devices that
+  // the IP-based pass missed (e.g. device whose /ip endpoint 404s but whose
+  // interface MACs appear in other devices' ARP tables).
+  for (const entry of allArpEntries) {
+    const seeingHostname = deviceIdToHostname.get(entry.device_id);
+    if (!seeingHostname) continue;
+    if (!activeDeviceIds.has(entry.device_id)) continue;
+
+    const mac = normalizeMac(entry.mac_address);
+    const macOwner = macToHostname.get(mac);
+    if (!macOwner || macOwner === seeingHostname) continue;
+    if (hostnameToLocation.get(seeingHostname) !== hostnameToLocation.get(macOwner)) continue;
+
+    const ifName = portIdToIfName.get(entry.port_id) ?? "";
+    if (ifName && isExcludedIface(ifName)) continue;
+
+    const key = [macOwner, seeingHostname].sort().join("<>");
+    if (linkSet.has(key)) continue;
+    linkSet.add(key);
+
+    const toMac = portIdToMac.get(entry.port_id);
+
+    arpLinks.push({
+      fromHostname: macOwner,
+      toHostname: seeingHostname,
+      fromIp: entry.ipv4_address,
+      toIp: hostnameToLocalIp.get(seeingHostname) ?? "",
+      mac: entry.mac_address,
+      fromInterface: undefined,
+      fromMac: mac,
+      toInterface: ifName || undefined,
+      toMac,
+    });
+  }
+
   // Build managed MAC set from ARP entries matching managed IPs (per-location).
   // MACs are globally unique, but the IP→MAC association must be checked against
   // the correct location to avoid false matches from overlapping subnets.
@@ -394,9 +444,26 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   // --- Consolidation: union-find to merge MACs sharing an IP and IPs sharing a MAC ---
   const arpDevices = consolidateArpDevices(allArpEntries, managedIpsByLocation, managedMacsByLocation, deviceIdToHostname, hostnameToLocation, isOverlayIp, portIdToIfName, portIdToMac, portIdToIp, activeDeviceIds);
 
+  // Discover LAN IPs for managed devices from ARP entries where a device's
+  // interface MAC is seen at a non-overlay, non-docker IP. This catches devices
+  // polled only via overlay whose /ip endpoint fails.
+  const arpLanIps = new Map<string, string>();
+  for (const entry of allArpEntries) {
+    const mac = normalizeMac(entry.mac_address);
+    const owner = macToHostname.get(mac);
+    if (!owner) continue;
+    if (arpLanIps.has(owner)) continue;
+    const ip = entry.ipv4_address;
+    if (!ip || ip === "0.0.0.0") continue;
+    if (engine.isOverlayIp(ip) || isDockerIp(ip)) continue;
+    if (isExcludedArpIp(ip)) continue;
+    arpLanIps.set(owner, ip);
+  }
+  cache.set("arpLanIps", arpLanIps, TTL.PORTS);
+
   cache.set("arpLinks", arpLinks, TTL.PORTS);
   cache.set("arpDevices", arpDevices, TTL.PORTS);
-  console.log(`[poller] Cached ${arpLinks.length} ARP links, ${arpDevices.length} discovered devices (consolidated) from ${allArpEntries.length} ARP entries`);
+  console.log(`[poller] Cached ${arpLinks.length} ARP links, ${arpDevices.length} discovered devices (consolidated), ${arpLanIps.size} ARP-discovered LAN IPs from ${allArpEntries.length} ARP entries`);
 
   const currArpDevices = new Set(arpDevices.map(d => {
     const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");

--- a/backend/src/librenms/types.ts
+++ b/backend/src/librenms/types.ts
@@ -10,6 +10,7 @@ export interface LnmsDevice {
   location: string;
   uptime: number;
   sysName: string;
+  display: string | null;
   hardware: string;
   features: string;
   serial: string;

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -11,6 +11,12 @@ function formatMac(raw: string): string {
   return hex.match(/.{2}/g)!.join(":");
 }
 
+function deriveDisplayName(device: LnmsDevice): string {
+  if (device.display) return device.display;
+  const name = device.sysName || device.hostname;
+  return name.replace(/\.local\.lan$/, "").replace(/\.local\.zt$/, "").replace(/\.[a-z]+\.[a-z]+$/, "");
+}
+
 const app = new Hono();
 
 app.get("/:hostname/overview", async (c) => {
@@ -63,12 +69,19 @@ app.get("/:hostname/overview", async (c) => {
     }))
     .filter((iface) => iface.mac && iface.mac !== "00:00:00:00:00:00");
 
+  const deviceIps = findDeviceIps(ips, ports);
+  if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+  const arpLanIps = cache.get<Map<string, string>>("arpLanIps");
+  const arpLanIp = arpLanIps?.get(hostname);
+  if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+
   const overview: DeviceOverview = {
     device: {
       device_id: device.device_id,
       hostname: device.hostname,
+      displayName: deriveDisplayName(device),
       ip: device.ip,
-      ips: findDeviceIps(ips, ports),
+      ips: deviceIps,
       os: device.os,
       version: device.version,
       icon: device.icon,

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -2,8 +2,14 @@ import { Hono } from "hono";
 import { cache, TTL } from "../cache/store.js";
 import { librenmsGet } from "../librenms/client.js";
 import { findDeviceIps, getOverlayPortSummaries, engine } from "../librenms/overlays.js";
-import type { DeviceOverview, DeviceRoute } from "@librenms-dash/shared";
+import type { DeviceOverview, DeviceInterface, DeviceRoute } from "@librenms-dash/shared";
 import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsAlert, LnmsHealthSensor } from "../librenms/types.js";
+
+function formatMac(raw: string): string {
+  const hex = raw.replace(/[^0-9a-fA-F]/g, "").toLowerCase();
+  if (hex.length !== 12) return "";
+  return hex.match(/.{2}/g)!.join(":");
+}
 
 const app = new Hono();
 
@@ -38,6 +44,24 @@ app.get("/:hostname/overview", async (c) => {
   const deviceAlerts = allAlerts.filter((a) => a.device_id === device.device_id);
 
   const ips = cache.get<LnmsDeviceIp[]>(`ips:${hostname}`) ?? [];
+
+  const ipsByPort = new Map<number, string[]>();
+  for (const ip of ips) {
+    if (!ip.ipv4_address) continue;
+    const arr = ipsByPort.get(ip.port_id);
+    if (arr) arr.push(ip.ipv4_address);
+    else ipsByPort.set(ip.port_id, [ip.ipv4_address]);
+  }
+
+  const interfaces: DeviceInterface[] = ports
+    .filter((p) => p.ifName !== "lo" && p.ifDescr !== "lo" && p.ifPhysAddress)
+    .map((p) => ({
+      ifName: p.ifName || p.ifDescr,
+      mac: formatMac(p.ifPhysAddress ?? ""),
+      ifOperStatus: p.ifOperStatus,
+      ips: ipsByPort.get(p.port_id) ?? [],
+    }))
+    .filter((iface) => iface.mac && iface.mac !== "00:00:00:00:00:00");
 
   const overview: DeviceOverview = {
     device: {
@@ -121,6 +145,7 @@ app.get("/:hostname/overview", async (c) => {
       state: a.state,
       timestamp: a.timestamp,
     })),
+    interfaces,
   };
 
   return c.json(overview);

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { cache } from "../cache/store.js";
 import type { TopologyResponse, Site, DeviceSummary, SubnetGroup, NeighborLink, ArpLink, ArpDiscoveredDevice, DeviceRoute } from "@librenms-dash/shared";
 import type { LnmsDevice, LnmsPort, LnmsLocation, LnmsAlert, LnmsDeviceIp, LnmsLink } from "../librenms/types.js";
-import { getOverlayPortSummaries, findLanIp, findDeviceIps, isExcludedIface } from "../librenms/overlays.js";
+import { getOverlayPortSummaries, findLanIp, findDeviceIps, isExcludedIface, engine } from "../librenms/overlays.js";
 import { normalizeMac } from "../librenms/oui.js";
 
 const commitSha: string | undefined = process.env.COMMIT_SHA || undefined;
@@ -10,7 +10,7 @@ const commitSha: string | undefined = process.env.COMMIT_SHA || undefined;
 const app = new Hono();
 
 function deriveDisplayName(device: LnmsDevice): string {
-  // Prefer sysName, strip FQDN domain parts
+  if (device.display) return device.display;
   const name = device.sysName || device.hostname;
   return name.replace(/\.local\.lan$/, "").replace(/\.local\.zt$/, "").replace(/\.[a-z]+\.[a-z]+$/, "");
 }
@@ -26,6 +26,8 @@ app.get("/", (c) => {
   for (const loc of locations) {
     locationMap.set(loc.location, loc);
   }
+
+  const arpLanIps = cache.get<Map<string, string>>("arpLanIps") ?? new Map<string, string>();
 
   const siteMap = new Map<string, Site>();
 
@@ -55,13 +57,20 @@ app.get("/", (c) => {
       if (mac && mac.length === 12 && mac !== "000000000000") macSet.add(mac);
     }
 
+    let lanIp = findLanIp(device.ip, ips, ports);
+    const deviceIps = findDeviceIps(ips, ports);
+    if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+    const arpLanIp = arpLanIps.get(device.hostname);
+    if (arpLanIp && engine.isOverlayIp(lanIp)) lanIp = arpLanIp;
+    if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+
     const summary: DeviceSummary = {
       device_id: device.device_id,
       hostname: device.hostname,
       displayName: deriveDisplayName(device),
       ip: device.ip,
-      lanIp: findLanIp(device.ip, ips, ports),
-      ips: findDeviceIps(ips, ports),
+      lanIp,
+      ips: deviceIps,
       macs: [...macSet],
       os: device.os,
       icon: device.icon,

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -1,9 +1,47 @@
-import { Component } from "react";
+import { Component, useState, useCallback } from "react";
 import type { ReactNode } from "react";
 import type { HealthSensor, Port, Alert, DeviceRoute, DeviceInterface } from "@librenms-dash/shared";
 import { useDeviceDetail } from "@/hooks/useDeviceDetail";
 import { graphUrl } from "@/lib/api";
 import { formatRate } from "@/lib/format";
+
+function copyToClipboard(text: string) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
+  } else {
+    fallbackCopy(text);
+  }
+}
+
+function fallbackCopy(text: string) {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+}
+
+function Copyable({ text, className, block, children }: { text: string; className?: string; block?: boolean; children?: ReactNode }) {
+  const [copied, setCopied] = useState(false);
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    copyToClipboard(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }, [text]);
+  return (
+    <span
+      className={`cursor-pointer ${block ? "block truncate" : ""}  ${copied ? "text-green-400" : `hover:text-white ${className ?? ""}`}`}
+      title={text}
+      onClick={handleClick}
+    >
+      {children ?? text}
+    </span>
+  );
+}
 
 interface Props {
   hostname: string;
@@ -96,36 +134,55 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${data.device.status === 1 ? "bg-green-500" : "bg-red-500"}`} />
-                <span className="font-bold text-base truncate">{data.device.sysName || data.device.hostname}</span>
+                <span className="font-bold text-base truncate">{data.device.displayName}</span>
               </div>
               <span className="text-xs text-gray-400">{data.device.os} {data.device.hardware ? `— ${data.device.hardware}` : ""}</span>
             </div>
           </div>
 
-          <table className="w-full mb-3 text-xs border-collapse rounded overflow-hidden" style={{ background: "rgba(255,255,255,0.05)" }}>
+          <table className="w-full mb-3 text-xs border-collapse rounded overflow-hidden table-fixed" style={{ background: "rgba(255,255,255,0.05)" }}>
+            <colgroup>
+              <col style={{ width: "76px" }} />
+              <col />
+            </colgroup>
             <tbody>
               {(() => {
                 const deviceIps = data.device.ips?.length ? data.device.ips : [data.device.ip];
                 const overlayLabels: Record<string, string> = { zerotier: "ZeroTier", wireguard: "WireGuard", tailscale: "Tailscale" };
                 const overlayIps = data.device.overlayIps ?? [];
-                const rows: [string, string, boolean?][] = [
-                  ...deviceIps.map((ip: string, i: number) => [i === 0 ? "IP" : "", ip, true] as [string, string, boolean]),
-                  ...overlayIps.map((o: { type: string; ip: string }, i: number) => [i === 0 ? "Overlay" : "", `${overlayLabels[o.type] ?? o.type}: ${o.ip}`, true] as [string, string, boolean]),
-                  ["Operating System", data.device.sysDescr || `${data.device.os} ${data.device.version}` || "—"],
+                const ipRows: [string, string, string][] = [
+                  ...deviceIps.map((ip: string, i: number) => [i === 0 ? "IP" : "", ip, ip] as [string, string, string]),
+                  ...overlayIps.map((o: { type: string; ip: string }, i: number) => [i === 0 ? "Overlay" : "", `${overlayLabels[o.type] ?? o.type}: ${o.ip}`, o.ip] as [string, string, string]),
+                ];
+                const textRows: [string, string, boolean?][] = [
+                  ["OS", data.device.sysDescr || `${data.device.os} ${data.device.version}` || "—"],
                   ["Hardware", data.device.hardware || "—"],
-                  ["Serial", data.device.serial || "—"],
+                  ["Serial", data.device.serial || "—", true],
                   ["Contact", data.device.sysContact || "—"],
                   ["Uptime", formatUptime(data.device.uptime)],
-                  ["Last Discovered", formatTimestamp(data.device.last_discovered)],
+                  ["Last Disc", formatTimestamp(data.device.last_discovered)],
                   ["Last Polled", formatTimestamp(data.device.last_polled)],
                   ["Location", data.device.location],
                 ];
-                return rows.map(([label, value, mono], i) => (
-                  <tr key={`${label}-${i}`} style={{ background: i % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
-                    <td className="py-1 px-2 text-gray-400 whitespace-nowrap align-top" style={{ width: "120px" }}>{label}</td>
-                    <td className={`py-1 px-2 break-words ${mono || label === "Serial" ? "font-mono" : ""}`}>{value}</td>
-                  </tr>
-                ));
+                let rowIdx = 0;
+                return (
+                  <>
+                    {ipRows.map(([label, display, copyVal], i) => (
+                      <tr key={`ip-${i}`} style={{ background: rowIdx++ % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
+                        <td className="py-1 px-2 text-gray-400 whitespace-nowrap align-top">{label}</td>
+                        <td className="py-1 px-2 font-mono">
+                          <Copyable text={copyVal} block>{display}</Copyable>
+                        </td>
+                      </tr>
+                    ))}
+                    {textRows.map(([label, value, mono], i) => (
+                      <tr key={`txt-${i}`} style={{ background: rowIdx++ % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
+                        <td className="py-1 px-2 text-gray-400 whitespace-nowrap align-top">{label}</td>
+                        <td className={`py-1 px-2 truncate ${mono ? "font-mono" : ""}`}>{value}</td>
+                      </tr>
+                    ))}
+                  </>
+                );
               })()}
             </tbody>
           </table>
@@ -167,7 +224,12 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
           {data.topPorts.length > 0 && (
             <div>
               <div className="text-xs text-gray-400 mb-1 font-semibold">Top Ports</div>
-              <table className="w-full text-xs border-collapse rounded overflow-hidden" style={{ background: "rgba(255,255,255,0.05)" }}>
+              <table className="w-full text-xs border-collapse rounded overflow-hidden table-fixed" style={{ background: "rgba(255,255,255,0.05)" }}>
+                <colgroup>
+                  <col className="w-[50%]" />
+                  <col className="w-[25%]" />
+                  <col className="w-[25%]" />
+                </colgroup>
                 <thead>
                   <tr style={{ background: "rgba(255,255,255,0.06)" }}>
                     <th className="py-1 px-2 text-left text-gray-400 font-semibold">Port</th>
@@ -178,7 +240,7 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                 <tbody>
                   {data.topPorts.map((p: Port, i: number) => (
                     <tr key={p.port_id} style={{ background: i % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
-                      <td className="py-1 px-2 truncate text-gray-300 max-w-[200px]">{p.ifName}{p.ifAlias && p.ifAlias !== p.ifName ? ` (${p.ifAlias})` : ""}</td>
+                      <td className="py-1 px-2 truncate text-gray-300">{p.ifName}{p.ifAlias && p.ifAlias !== p.ifName ? ` (${p.ifAlias})` : ""}</td>
                       <td className="py-1 px-2 text-right font-mono whitespace-nowrap text-green-400">↓{formatRate(p.ifInOctets_rate)}</td>
                       <td className="py-1 px-2 text-right font-mono whitespace-nowrap text-blue-400">↑{formatRate(p.ifOutOctets_rate)}</td>
                     </tr>
@@ -191,7 +253,12 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
           {data.routes.length > 0 && (
             <div className="mt-3">
               <div className="text-xs text-gray-400 mb-1 font-semibold">Routes</div>
-              <table className="w-full text-xs border-collapse rounded overflow-hidden" style={{ background: "rgba(255,255,255,0.05)" }}>
+              <table className="w-full text-xs border-collapse rounded overflow-hidden table-fixed" style={{ background: "rgba(255,255,255,0.05)" }}>
+                <colgroup>
+                  <col className="w-[40%]" />
+                  <col className="w-[40%]" />
+                  <col className="w-[20%]" />
+                </colgroup>
                 <thead>
                   <tr style={{ background: "rgba(255,255,255,0.06)" }}>
                     <th className="py-1 px-1.5 text-left text-gray-400 font-semibold">Dst/Mask</th>
@@ -202,14 +269,16 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                 <tbody>
                   {data.routes.map((r: DeviceRoute, i: number) => (
                     <tr key={`${r.dest}-${r.prefix}-${r.nextHop}`} style={{ background: i % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
-                      <td className="py-0.5 px-1.5 font-mono text-gray-300 whitespace-nowrap">{r.dest}/{r.prefix}</td>
+                      <td className="py-0.5 px-1.5 font-mono text-gray-300">
+                        <Copyable text={`${r.dest}/${r.prefix}`} block>{r.dest}/{r.prefix}</Copyable>
+                      </td>
                       <td className="py-0.5 px-1.5 font-mono">
-                        <span className="text-gray-300">{r.nextHop}</span>
+                        <Copyable text={r.nextHop} className="text-gray-300" block>{r.nextHop}</Copyable>
                         {r.nextHopDevice && (
-                          <div className="text-[10px] text-cyan-400 leading-tight">{r.nextHopDevice}</div>
+                          <div className="text-[10px] text-cyan-400 leading-tight truncate">{r.nextHopDevice}</div>
                         )}
                       </td>
-                      <td className="py-0.5 px-1.5 text-gray-400 truncate max-w-[90px]">{r.iface}</td>
+                      <td className="py-0.5 px-1.5 text-gray-400 truncate">{r.iface}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -229,7 +298,12 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
           {data.interfaces.length > 0 && (
             <div className="mt-3">
               <div className="text-xs text-gray-400 mb-1 font-semibold">Interfaces</div>
-              <table className="w-full text-xs border-collapse rounded overflow-hidden" style={{ background: "rgba(255,255,255,0.05)" }}>
+              <table className="w-full text-xs border-collapse rounded overflow-hidden table-fixed" style={{ background: "rgba(255,255,255,0.05)" }}>
+                <colgroup>
+                  <col className="w-[25%]" />
+                  <col className="w-[40%]" />
+                  <col className="w-[35%]" />
+                </colgroup>
                 <thead>
                   <tr style={{ background: "rgba(255,255,255,0.06)" }}>
                     <th className="py-1 px-2 text-left text-gray-400 font-semibold">Name</th>
@@ -240,12 +314,23 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                 <tbody>
                   {data.interfaces.map((iface: DeviceInterface, i: number) => (
                     <tr key={iface.ifName} style={{ background: i % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
-                      <td className="py-0.5 px-2 text-gray-300 whitespace-nowrap">
+                      <td className="py-0.5 px-2 text-gray-300 truncate">
                         <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1 ${iface.ifOperStatus === "up" ? "bg-green-500" : "bg-red-500"}`} />
                         {iface.ifName}
                       </td>
-                      <td className="py-0.5 px-2 font-mono text-gray-400">{iface.mac}</td>
-                      <td className="py-0.5 px-2 font-mono text-gray-300">{iface.ips.join(", ") || "—"}</td>
+                      <td className="py-0.5 px-2 font-mono text-gray-400">
+                        <Copyable text={iface.mac} block>{iface.mac}</Copyable>
+                      </td>
+                      <td className="py-0.5 px-2 font-mono text-gray-300 truncate">
+                        {iface.ips.length > 0
+                          ? iface.ips.map((ip, j) => (
+                              <span key={ip}>
+                                {j > 0 && ", "}
+                                <Copyable text={ip}>{ip}</Copyable>
+                              </span>
+                            ))
+                          : "—"}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -1,6 +1,6 @@
 import { Component } from "react";
 import type { ReactNode } from "react";
-import type { HealthSensor, Port, Alert, DeviceRoute } from "@librenms-dash/shared";
+import type { HealthSensor, Port, Alert, DeviceRoute, DeviceInterface } from "@librenms-dash/shared";
 import { useDeviceDetail } from "@/hooks/useDeviceDetail";
 import { graphUrl } from "@/lib/api";
 import { formatRate } from "@/lib/format";
@@ -223,6 +223,33 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
               {data.alerts.map((a: Alert) => (
                 <div key={a.id} className="text-xs text-red-300">{a.rule}</div>
               ))}
+            </div>
+          )}
+
+          {data.interfaces.length > 0 && (
+            <div className="mt-3">
+              <div className="text-xs text-gray-400 mb-1 font-semibold">Interfaces</div>
+              <table className="w-full text-xs border-collapse rounded overflow-hidden" style={{ background: "rgba(255,255,255,0.05)" }}>
+                <thead>
+                  <tr style={{ background: "rgba(255,255,255,0.06)" }}>
+                    <th className="py-1 px-2 text-left text-gray-400 font-semibold">Name</th>
+                    <th className="py-1 px-2 text-left text-gray-400 font-semibold">MAC</th>
+                    <th className="py-1 px-2 text-left text-gray-400 font-semibold">IPs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.interfaces.map((iface: DeviceInterface, i: number) => (
+                    <tr key={iface.ifName} style={{ background: i % 2 === 0 ? "rgba(255,255,255,0.03)" : "transparent" }}>
+                      <td className="py-0.5 px-2 text-gray-300 whitespace-nowrap">
+                        <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1 ${iface.ifOperStatus === "up" ? "bg-green-500" : "bg-red-500"}`} />
+                        {iface.ifName}
+                      </td>
+                      <td className="py-0.5 px-2 font-mono text-gray-400">{iface.mac}</td>
+                      <td className="py-0.5 px-2 font-mono text-gray-300">{iface.ips.join(", ") || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,12 +171,20 @@ export interface TopologyResponse {
   commitSha?: string;
 }
 
+export interface DeviceInterface {
+  ifName: string;
+  mac: string;
+  ifOperStatus: string;
+  ips: string[];
+}
+
 export interface DeviceOverview {
   device: Device;
   health: HealthSensor[];
   topPorts: Port[];
   alerts: Alert[];
   routes: DeviceRoute[];
+  interfaces: DeviceInterface[];
 }
 
 export interface AssetEvent {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,6 +1,7 @@
 export interface Device {
   device_id: number;
   hostname: string;
+  displayName: string;
   ip: string;
   ips: string[];
   os: string;


### PR DESCRIPTION
## Summary
- **Display Name**: Use LibreNMS "Display Name" field as priority for device name in topology boxes and popover, falling back to sysName → hostname
- **ARP-discovered LAN IPs**: Discover LAN IPs from ARP tables for overlay-only devices whose `/ip` endpoint fails (e.g. OpenWrt/Zyxel polled via ZeroTier). Displayed alongside the overlay IP, not replacing it
- **MAC-based ARP links**: Build ARP links via interface MAC matching so overlay-only devices connect to neighbors in the topology even when IP-based matching misses
- **Resilient polling**: Use `Promise.allSettled` for port/IP fetches so a failed IP fetch no longer prevents port data from being cached
- **Device popover interfaces**: Show all interfaces with MAC addresses and IPs at the bottom of the device popover
- **Popover UX**: Shrink label column (76px), CSS-only truncation for long values, click-to-copy with `execCommand` fallback for non-HTTPS contexts, shortened field labels (OS, Last Disc)
- **Build docs**: Added "Build & Verify" section to CLAUDE.md and AGENTS.md requiring `docker-compose up -d --build`

## Test plan
- [ ] Verify Zyxel (172.29.0.31) shows LAN IP 192.168.1.1 + overlay IP on device box and popover
- [ ] Verify Zyxel shows ARP link to blr02 in topology
- [ ] Verify Zyxel shows interfaces with MAC addresses in popover
- [ ] Verify display names from LibreNMS appear on device boxes and popover headers
- [ ] Verify click-to-copy works on IPs and MACs in popover
- [ ] Verify no horizontal scroll in popover with long IPv6 addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)