### PR TITLE
misc: UX fixes, PWA icon, scroll zoom granularity, click-to-copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,15 @@ dist/
 .grok/
 .vscode/
 .idea/
+.claude.json
+.mcp.json
+
+# Python virtualenv
+bin/
+lib/
+lib64
+pyvenv.cfg
+share/
 
 # Reproducible IEEE OUI databases (fetched by scripts/download-oui.sh or the Docker build)
 /data/*.csv

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { PORT } from "./config.js";
@@ -23,17 +24,38 @@ app.use("*", cors({
 }));
 
 let cacheReady = false;
+const cacheReadyListeners = new Set<() => void>();
+
+function onCacheReady(fn: () => void) { cacheReadyListeners.add(fn); }
+function offCacheReady(fn: () => void) { cacheReadyListeners.delete(fn); }
 
 app.get("/api/health", (c) => c.json({ status: cacheReady ? "ok" : "warming", uptime: process.uptime() }));
+
+app.get("/api/health/stream", (c) => {
+  return streamSSE(c, async (stream) => {
+    if (cacheReady) {
+      await stream.writeSSE({ data: "ok", event: "ready" });
+      return;
+    }
+    const notify = () => {
+      stream.writeSSE({ data: "ok", event: "ready" }).catch(() => {});
+    };
+    onCacheReady(notify);
+    stream.onAbort(() => offCacheReady(notify));
+    while (!stream.aborted && !cacheReady) {
+      await stream.sleep(5_000);
+    }
+  });
+});
 
 app.route("/api/auth", authRoutes);
 
 app.use("/api/*", async (c, next) => {
-  if (c.req.path.startsWith("/api/auth")) {
+  if (c.req.path.startsWith("/api/auth") || c.req.path.startsWith("/api/health")) {
     await next();
     return;
   }
-  if (!cacheReady && c.req.path !== "/api/health") {
+  if (!cacheReady) {
     return c.json({ error: "Cache warming, try again shortly" }, 503);
   }
   await next();
@@ -61,6 +83,8 @@ async function main() {
   });
   await warmCache();
   cacheReady = true;
+  for (const fn of cacheReadyListeners) fn();
+  cacheReadyListeners.clear();
   startPoller();
   console.log(`[librenms-dash] Cache ready — serving requests`);
 }

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -38,6 +38,7 @@ const prevAssets = {
   routes: new Set<string>(),
 };
 const assetBaseline = new Set<string>();
+const prevDeviceStatus = new Map<string, number>();
 let eventSeq = 0;
 const MAX_EVENTS = 200;
 
@@ -137,6 +138,17 @@ export async function pollDevicesAndLocations() {
 
   const currDevices = new Set(devices.map(d => `${d.hostname} (${d.ip})`));
   prevAssets.devices = diffAndLog("device", prevAssets.devices, currDevices);
+
+  for (const d of devices) {
+    const prev = prevDeviceStatus.get(d.hostname);
+    if (prev !== undefined && prev !== d.status) {
+      const label = d.status === 1 ? "up" : "down";
+      console.log(`${localTimestamp()} [status] ${d.hostname} went ${label}`);
+      topologyChangedInCycle = true;
+    }
+    prevDeviceStatus.set(d.hostname, d.status);
+  }
+
   flushTopologyChanged();
 }
 
@@ -686,9 +698,26 @@ export async function pollRoutes() {
   flushTopologyChanged();
 }
 
+let prevAlertIds = new Set<number>();
+
 export async function pollAlerts() {
   const alerts = await fetchAlerts();
   cache.set("alerts", alerts, TTL.ALERTS);
+
+  const currIds = new Set(alerts.map(a => a.id));
+  if (prevAlertIds.size > 0 || currIds.size > 0) {
+    let changed = currIds.size !== prevAlertIds.size;
+    if (!changed) {
+      for (const id of currIds) {
+        if (!prevAlertIds.has(id)) { changed = true; break; }
+      }
+    }
+    if (changed) {
+      topologyChangedInCycle = true;
+      flushTopologyChanged();
+    }
+  }
+  prevAlertIds = currIds;
 }
 
 export async function warmCache() {

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -14,7 +14,7 @@ function formatMac(raw: string): string {
 function deriveDisplayName(device: LnmsDevice): string {
   if (device.display) return device.display;
   const name = device.sysName || device.hostname;
-  return name.replace(/\.local\.lan$/, "").replace(/\.local\.zt$/, "").replace(/\.[a-z]+\.[a-z]+$/, "");
+  return name.replace(/\..*$/, "");
 }
 
 const app = new Hono();
@@ -59,8 +59,9 @@ app.get("/:hostname/overview", async (c) => {
     else ipsByPort.set(ip.port_id, [ip.ipv4_address]);
   }
 
+  const dockerVethRe = /^br-[a-f0-9]{12}$|^docker0$|^veth[a-f0-9]+$/;
   const interfaces: DeviceInterface[] = ports
-    .filter((p) => p.ifName !== "lo" && p.ifDescr !== "lo" && p.ifPhysAddress)
+    .filter((p) => p.ifName !== "lo" && p.ifDescr !== "lo" && p.ifPhysAddress && !dockerVethRe.test(p.ifName || p.ifDescr))
     .map((p) => ({
       ifName: p.ifName || p.ifDescr,
       mac: formatMac(p.ifPhysAddress ?? ""),
@@ -128,7 +129,7 @@ app.get("/:hostname/overview", async (c) => {
       const samesite = new Map<string, string>();
       const overlay = new Map<string, string>();
       for (const d of devices) {
-        const name = d.sysName?.replace(/\.local\.lan$/, "").replace(/\.local\.zt$/, "") || d.hostname;
+        const name = deriveDisplayName(d);
         const sameLoc = d.location === device.location;
         const dPorts = cache.get<LnmsPort[]>(`ports:${d.hostname}`) ?? [];
         const overlayPortIds = new Set(dPorts.filter((p) => engine.classifyPort(p)).map((p) => p.port_id));
@@ -143,6 +144,16 @@ app.get("/:hostname/overview", async (c) => {
         }
         if (engine.isOverlayIp(d.ip)) { overlayIps.add(d.ip); overlay.set(d.ip, name); }
         else if (sameLoc) samesite.set(d.ip, name);
+      }
+      const arpLanIpMap = cache.get<Map<string, string>>("arpLanIps");
+      if (arpLanIpMap) {
+        for (const d of devices) {
+          if (d.location !== device.location) continue;
+          const arpIp = arpLanIpMap.get(d.hostname);
+          if (arpIp && !overlay.has(arpIp) && !samesite.has(arpIp)) {
+            samesite.set(arpIp, deriveDisplayName(d));
+          }
+        }
       }
       return routes.map((r) => ({
         ...r,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#030712" />
     <title>LibreNMS-Dash — Network Dashboard</title>
   </head>
   <body class="bg-gray-950 text-gray-100 m-0 overflow-hidden">

--- a/frontend/public/logo-maskable.svg
+++ b/frontend/public/logo-maskable.svg
@@ -1,0 +1,44 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Dark background fill with rounded corners -->
+  <rect width="512" height="512" rx="115" ry="115" fill="#030712"/>
+
+  <!-- Outer ring -->
+  <circle cx="256" cy="256" r="238" stroke="#74b743" stroke-width="10" stroke-opacity="0.35"/>
+  <circle cx="256" cy="256" r="238" stroke="#74b743" stroke-width="3.5" stroke-opacity="0.7"/>
+
+  <!-- Network links -->
+  <line x1="256" y1="154" x2="154" y2="290" stroke="#74b743" stroke-width="8.5" stroke-opacity="0.5"/>
+  <line x1="256" y1="154" x2="358" y2="290" stroke="#74b743" stroke-width="8.5" stroke-opacity="0.5"/>
+  <line x1="154" y1="290" x2="358" y2="290" stroke="#74b743" stroke-width="8.5" stroke-opacity="0.5"/>
+  <line x1="154" y1="290" x2="188" y2="384" stroke="#38bdf8" stroke-width="6.5" stroke-opacity="0.4"/>
+  <line x1="358" y1="290" x2="324" y2="384" stroke="#fbbf24" stroke-width="6.5" stroke-opacity="0.4"/>
+  <line x1="256" y1="154" x2="256" y2="86" stroke="#74b743" stroke-width="6.5" stroke-opacity="0.3"/>
+
+  <!-- Central hub node -->
+  <circle cx="256" cy="154" r="42" fill="#74b743" fill-opacity="0.15" stroke="#74b743" stroke-width="8.5"/>
+  <circle cx="256" cy="154" r="17" fill="#74b743"/>
+
+  <!-- Left node -->
+  <circle cx="154" cy="290" r="34" fill="#38bdf8" fill-opacity="0.1" stroke="#38bdf8" stroke-width="6.5"/>
+  <circle cx="154" cy="290" r="15" fill="#38bdf8"/>
+
+  <!-- Right node -->
+  <circle cx="358" cy="290" r="34" fill="#fbbf24" fill-opacity="0.1" stroke="#fbbf24" stroke-width="6.5"/>
+  <circle cx="358" cy="290" r="15" fill="#fbbf24"/>
+
+  <!-- Leaf nodes -->
+  <circle cx="188" cy="384" r="17" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-width="4"/>
+  <circle cx="188" cy="384" r="8.5" fill="#38bdf8" fill-opacity="0.7"/>
+
+  <circle cx="324" cy="384" r="17" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-width="4"/>
+  <circle cx="324" cy="384" r="8.5" fill="#fbbf24" fill-opacity="0.7"/>
+
+  <!-- Top pulse -->
+  <circle cx="256" cy="86" r="13" fill="none" stroke="#74b743" stroke-width="4" stroke-opacity="0.5"/>
+  <circle cx="256" cy="86" r="6.5" fill="#74b743" fill-opacity="0.6"/>
+
+  <!-- Dashboard bars -->
+  <rect x="222" y="426" width="17" height="43" rx="4" fill="#74b743" fill-opacity="0.6"/>
+  <rect x="247" y="409" width="17" height="60" rx="4" fill="#74b743" fill-opacity="0.8"/>
+  <rect x="273" y="418" width="17" height="51" rx="4" fill="#74b743" fill-opacity="0.7"/>
+</svg>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,41 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Outer ring — dark border with subtle green glow -->
+  <circle cx="60" cy="60" r="56" stroke="#74b743" stroke-width="2.5" stroke-opacity="0.35"/>
+  <circle cx="60" cy="60" r="56" stroke="#74b743" stroke-width="0.8" stroke-opacity="0.7"/>
+
+  <!-- Network links -->
+  <line x1="60" y1="36" x2="36" y2="68" stroke="#74b743" stroke-width="2" stroke-opacity="0.5"/>
+  <line x1="60" y1="36" x2="84" y2="68" stroke="#74b743" stroke-width="2" stroke-opacity="0.5"/>
+  <line x1="36" y1="68" x2="84" y2="68" stroke="#74b743" stroke-width="2" stroke-opacity="0.5"/>
+  <line x1="36" y1="68" x2="44" y2="90" stroke="#38bdf8" stroke-width="1.5" stroke-opacity="0.4"/>
+  <line x1="84" y1="68" x2="76" y2="90" stroke="#fbbf24" stroke-width="1.5" stroke-opacity="0.4"/>
+  <line x1="60" y1="36" x2="60" y2="20" stroke="#74b743" stroke-width="1.5" stroke-opacity="0.3"/>
+
+  <!-- Central hub node — bright green -->
+  <circle cx="60" cy="36" r="10" fill="#74b743" fill-opacity="0.15" stroke="#74b743" stroke-width="2"/>
+  <circle cx="60" cy="36" r="4" fill="#74b743"/>
+
+  <!-- Left node -->
+  <circle cx="36" cy="68" r="8" fill="#38bdf8" fill-opacity="0.1" stroke="#38bdf8" stroke-width="1.5"/>
+  <circle cx="36" cy="68" r="3.5" fill="#38bdf8"/>
+
+  <!-- Right node -->
+  <circle cx="84" cy="68" r="8" fill="#fbbf24" fill-opacity="0.1" stroke="#fbbf24" stroke-width="1.5"/>
+  <circle cx="84" cy="68" r="3.5" fill="#fbbf24"/>
+
+  <!-- Leaf nodes — discovered/edge devices -->
+  <circle cx="44" cy="90" r="4" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-width="1"/>
+  <circle cx="44" cy="90" r="2" fill="#38bdf8" fill-opacity="0.7"/>
+
+  <circle cx="76" cy="90" r="4" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-width="1"/>
+  <circle cx="76" cy="90" r="2" fill="#fbbf24" fill-opacity="0.7"/>
+
+  <!-- Top pulse — signal indicator -->
+  <circle cx="60" cy="20" r="3" fill="none" stroke="#74b743" stroke-width="1" stroke-opacity="0.5"/>
+  <circle cx="60" cy="20" r="1.5" fill="#74b743" fill-opacity="0.6"/>
+
+  <!-- Dashboard bars — the "Dash" element -->
+  <rect x="52" y="100" width="4" height="10" rx="1" fill="#74b743" fill-opacity="0.6"/>
+  <rect x="58" y="96" width="4" height="14" rx="1" fill="#74b743" fill-opacity="0.8"/>
+  <rect x="64" y="98" width="4" height="12" rx="1" fill="#74b743" fill-opacity="0.7"/>
+</svg>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "LibreNMS-Dash",
+  "short_name": "LibreNMS",
+  "description": "Network topology dashboard for LibreNMS",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#030712",
+  "theme_color": "#030712",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/logo-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,15 +17,17 @@ function AuthLoadingScreen({ message }: { message: string }) {
 }
 
 function Dashboard() {
-  const { data, isLoading, error } = useTopology();
+  const { data, isLoading, error, warming } = useTopology();
   const sse = useSSE();
 
-  if (isLoading) {
+  if (isLoading || warming) {
     return (
       <div className="h-full w-full flex items-center justify-center bg-gray-950">
         <div className="text-center">
           <div className="w-8 h-8 border-2 border-gray-600 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-gray-400 text-sm">Loading topology from LibreNMS...</p>
+          <p className="text-gray-400 text-sm">
+            {warming ? "Server is starting up — waiting for cache..." : "Loading topology from LibreNMS..."}
+          </p>
         </div>
       </div>
     );

--- a/frontend/src/components/AssetEventToast.tsx
+++ b/frontend/src/components/AssetEventToast.tsx
@@ -1,5 +1,22 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { AssetEvent } from "@librenms-dash/shared";
+import { Copyable } from "./Copyable";
+
+function CopyableAsset({ category, asset }: { category: string; asset: string }) {
+  if (category === "ip") {
+    const spaceIdx = asset.lastIndexOf(" ");
+    const ip = spaceIdx === -1 ? asset : asset.slice(spaceIdx + 1);
+    const prefix = spaceIdx === -1 ? "" : asset.slice(0, spaceIdx);
+    return <>{prefix && <span className="text-gray-500">{prefix} </span>}<Copyable text={ip}>{ip}</Copyable></>;
+  }
+  if (category === "discovered-device") {
+    const atIdx = asset.indexOf(" at ");
+    if (atIdx !== -1) {
+      return <><Copyable text={asset.slice(0, atIdx)}>{asset.slice(0, atIdx)}</Copyable><span className="text-gray-500">{asset.slice(atIdx)}</span></>;
+    }
+  }
+  return <>{asset}</>;
+}
 
 const TOAST_DURATION_MS = 5_000;
 const TOAST_GAP_MS = 1_500;
@@ -207,7 +224,9 @@ export function AssetEventToast({ allEvents, connected }: AssetEventToastProps) 
                           </span>
                         </td>
                         <td className="py-1 px-2 text-gray-400 whitespace-nowrap capitalize">{e.category}</td>
-                        <td className="py-1 px-2 text-gray-300 truncate max-w-[180px]" title={e.asset}>{e.asset}</td>
+                        <td className="py-1 px-2 text-gray-300 truncate max-w-[180px]" title={e.asset}>
+                          <CopyableAsset category={e.category} asset={e.asset} />
+                        </td>
                       </tr>
                     ))}
                   </tbody>

--- a/frontend/src/components/Copyable.tsx
+++ b/frontend/src/components/Copyable.tsx
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+import type { ReactNode } from "react";
+
+function copyToClipboard(text: string) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
+  } else {
+    fallbackCopy(text);
+  }
+}
+
+function fallbackCopy(text: string) {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+}
+
+export function Copyable({ text, className, block, children }: { text: string; className?: string; block?: boolean; children?: ReactNode }) {
+  const [copied, setCopied] = useState(false);
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    copyToClipboard(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }, [text]);
+  return (
+    <span
+      className={`cursor-pointer ${block ? "block truncate" : ""}  ${copied ? "text-green-400" : `hover:text-white ${className ?? ""}`}`}
+      title={text}
+      onClick={handleClick}
+    >
+      {children ?? text}
+    </span>
+  );
+}

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -1,47 +1,10 @@
-import { Component, useState, useCallback } from "react";
+import { Component } from "react";
 import type { ReactNode } from "react";
 import type { HealthSensor, Port, Alert, DeviceRoute, DeviceInterface } from "@librenms-dash/shared";
 import { useDeviceDetail } from "@/hooks/useDeviceDetail";
 import { graphUrl } from "@/lib/api";
 import { formatRate } from "@/lib/format";
-
-function copyToClipboard(text: string) {
-  if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
-  } else {
-    fallbackCopy(text);
-  }
-}
-
-function fallbackCopy(text: string) {
-  const ta = document.createElement("textarea");
-  ta.value = text;
-  ta.style.position = "fixed";
-  ta.style.opacity = "0";
-  document.body.appendChild(ta);
-  ta.select();
-  document.execCommand("copy");
-  document.body.removeChild(ta);
-}
-
-function Copyable({ text, className, block, children }: { text: string; className?: string; block?: boolean; children?: ReactNode }) {
-  const [copied, setCopied] = useState(false);
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    copyToClipboard(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
-  }, [text]);
-  return (
-    <span
-      className={`cursor-pointer ${block ? "block truncate" : ""}  ${copied ? "text-green-400" : `hover:text-white ${className ?? ""}`}`}
-      title={text}
-      onClick={handleClick}
-    >
-      {children ?? text}
-    </span>
-  );
-}
+import { Copyable } from "./Copyable";
 
 interface Props {
   hostname: string;
@@ -321,13 +284,12 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                       <td className="py-0.5 px-2 font-mono text-gray-400">
                         <Copyable text={iface.mac} block>{iface.mac}</Copyable>
                       </td>
-                      <td className="py-0.5 px-2 font-mono text-gray-300 truncate">
+                      <td className="py-0.5 px-2 font-mono text-gray-300">
                         {iface.ips.length > 0
-                          ? iface.ips.map((ip, j) => (
-                              <span key={ip}>
-                                {j > 0 && ", "}
+                          ? iface.ips.map((ip) => (
+                              <div key={ip} className="leading-tight">
                                 <Copyable text={ip}>{ip}</Copyable>
-                              </span>
+                              </div>
                             ))
                           : "—"}
                       </td>

--- a/frontend/src/components/LinkTooltip.tsx
+++ b/frontend/src/components/LinkTooltip.tsx
@@ -1,3 +1,5 @@
+import { Copyable } from "./Copyable";
+
 export interface LinkTooltipData {
   type: "lldp" | "arp" | "overlay" | "arp-device";
   screenX: number;
@@ -70,12 +72,12 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             <SectionLabel label="Seen by" />
             <Row label="Device" value={data.sourceDisplayName} />
             {data.interface && <Row label="Interface" value={data.interface} mono />}
-            {data.sourceIp && <Row label="IP" value={data.sourceIp} mono />}
-            {data.sourceMac && <Row label="MAC" value={data.sourceMac} mono />}
+            {data.sourceIp && <Row label="IP" value={data.sourceIp} mono copyable />}
+            {data.sourceMac && <Row label="MAC" value={data.sourceMac} mono copyable />}
             <SectionLabel label="Discovered device" />
             <Row label="Vendor" value={data.vendor || data.targetDisplayName || "Unknown"} />
-            <Row label="IP" value={data.targetIp ?? "—"} mono />
-            <Row label="MAC" value={data.mac ?? "—"} mono />
+            <Row label="IP" value={data.targetIp ?? "—"} mono copyable />
+            <Row label="MAC" value={data.mac ?? "—"} mono copyable />
           </tbody>
         </table>
       ) : data.type === "arp" ? (
@@ -84,13 +86,13 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             <SectionLabel label="Device" />
             <Row label="Name" value={data.sourceDisplayName} />
             {data.sourceInterface && <Row label="Interface" value={data.sourceInterface} mono />}
-            {data.sourceIp && <Row label="IP" value={data.sourceIp} mono />}
-            {data.mac && <Row label="MAC" value={data.mac} mono />}
+            {data.sourceIp && <Row label="IP" value={data.sourceIp} mono copyable />}
+            {data.mac && <Row label="MAC" value={data.mac} mono copyable />}
             <SectionLabel label="Seen by" />
             <Row label="Device" value={data.targetDisplayName} />
             {data.targetInterface && <Row label="Interface" value={data.targetInterface} mono />}
-            {data.targetIp && <Row label="IP" value={data.targetIp} mono />}
-            {data.targetMac && <Row label="MAC" value={data.targetMac} mono />}
+            {data.targetIp && <Row label="IP" value={data.targetIp} mono copyable />}
+            {data.targetMac && <Row label="MAC" value={data.targetMac} mono copyable />}
           </tbody>
         </table>
       ) : (
@@ -130,8 +132,8 @@ function DeviceSection({ role, device, iface, ip, ipLabel = "IP", mac }: {
       <SectionLabel label={role} />
       <Row label="Device" value={device} />
       {iface && <Row label="Interface" value={iface} mono />}
-      {ip && <Row label={ipLabel} value={ip} mono />}
-      {mac && <Row label="MAC" value={mac} mono />}
+      {ip && <Row label={ipLabel} value={ip} mono copyable />}
+      {mac && <Row label="MAC" value={mac} mono copyable />}
     </>
   );
 }
@@ -146,11 +148,13 @@ function SectionLabel({ label }: { label: string }) {
   );
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+function Row({ label, value, mono, copyable }: { label: string; value: string; mono?: boolean; copyable?: boolean }) {
   return (
     <tr>
       <td className="py-0.5 pr-2 text-gray-500 whitespace-nowrap align-top">{label}</td>
-      <td className={`py-0.5 text-gray-200 break-all ${mono ? "font-mono" : ""}`}>{value}</td>
+      <td className={`py-0.5 text-gray-200 break-all ${mono ? "font-mono" : ""}`}>
+        {copyable && value && value !== "—" ? <Copyable text={value}>{value}</Copyable> : value}
+      </td>
     </tr>
   );
 }

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -552,7 +552,7 @@ export function TopologyMap({ data, sse }: Props) {
       const rect = el.getBoundingClientRect();
       if (e.ctrlKey) {
         // Trackpad pinch and Ctrl+wheel both arrive here; deltaY is the pinch amount.
-        zoomAt(Math.exp(-e.deltaY * 0.01), e.clientX - rect.left, e.clientY - rect.top);
+        zoomAt(Math.exp(-e.deltaY * 0.003), e.clientX - rect.left, e.clientY - rect.top);
       } else {
         setTransform((prev) => ({ ...prev, x: prev.x - e.deltaX, y: prev.y - e.deltaY }));
       }

--- a/frontend/src/hooks/useTopology.ts
+++ b/frontend/src/hooks/useTopology.ts
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchTopology } from "@/lib/api";
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchTopology, ServerWarmingError } from "@/lib/api";
 import type { TopologyResponse } from "@librenms-dash/shared";
 
-const STEADY_INTERVAL = 5 * 60 * 1000; // 5 min once data is complete
-const LOADING_INTERVAL = 10 * 1000; // 10s while backend is still populating
+const STEADY_INTERVAL = 5 * 60 * 1000;
+const LOADING_INTERVAL = 10 * 1000;
 
 function isDataIncomplete(data: TopologyResponse | undefined): boolean {
   if (!data) return true;
@@ -11,12 +12,50 @@ function isDataIncomplete(data: TopologyResponse | undefined): boolean {
 }
 
 export function useTopology() {
-  return useQuery({
+  const queryClient = useQueryClient();
+  const [warming, setWarming] = useState(false);
+
+  const query = useQuery({
     queryKey: ["topology"],
     queryFn: fetchTopology,
-    refetchInterval: (query) => {
-      return isDataIncomplete(query.state.data) ? LOADING_INTERVAL : STEADY_INTERVAL;
+    refetchInterval: (q) => {
+      if (q.state.error instanceof ServerWarmingError) return false;
+      return isDataIncomplete(q.state.data) ? LOADING_INTERVAL : STEADY_INTERVAL;
+    },
+    retry: (failureCount, error) => {
+      if (error instanceof ServerWarmingError) return false;
+      return failureCount < 3;
     },
     staleTime: 0,
   });
+
+  const isWarming = query.error instanceof ServerWarmingError;
+
+  useEffect(() => {
+    if (!isWarming) {
+      setWarming(false);
+      return;
+    }
+    setWarming(true);
+
+    const es = new EventSource("/api/health/stream");
+
+    es.addEventListener("ready", () => {
+      es.close();
+      setWarming(false);
+      queryClient.invalidateQueries({ queryKey: ["topology"] });
+    });
+
+    es.onerror = () => {
+      es.close();
+      const timer = setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["topology"] });
+      }, 3000);
+      return () => clearTimeout(timer);
+    };
+
+    return () => es.close();
+  }, [isWarming, queryClient]);
+
+  return { ...query, warming };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,9 +2,17 @@ import type { TopologyResponse, DeviceOverview } from "@librenms-dash/shared";
 
 const BASE = "/api";
 
+export class ServerWarmingError extends Error {
+  constructor() {
+    super("Server is starting up");
+    this.name = "ServerWarmingError";
+  }
+}
+
 async function get<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, { credentials: "include" });
   if (res.status === 401) throw new Error("Unauthorized");
+  if (res.status === 503) throw new ServerWarmingError();
   if (!res.ok) throw new Error(`API ${path}: ${res.status}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary

- **PWA icon**: add `manifest.webmanifest` with dark `background_color`/`theme_color` so the Chrome web app no longer shows a white icon background; add `logo.svg` (full-fidelity) and `logo-maskable.svg` (512px, rounded corners, dark fill) as standalone SVG assets
- **Scroll zoom**: reduce Ctrl+wheel zoom multiplier `0.01 → 0.003` for finer granularity per scroll step
- **Click-to-copy in asset change log**: IP address and MAC address values in the event log are now clickable to copy (hostname / location context shown dimmed alongside)
- **Link tooltip click-to-copy**: MAC and IP copyable in link popovers
- **Loading screen**: show loading indicator during cache warmup; live-update device status and alerts
- **Interface filter**: filter docker/veth interfaces from popovers

## Test plan

- [ ] Install app as Chrome PWA — icon should appear on dark background, no white surround
- [ ] Ctrl+scroll on topology map — zoom should increment in smaller steps
- [ ] Open asset change log, find an IP or discovered-device row — click the IP/MAC value, verify clipboard contains the value and it flashes green
- [ ] Other asset categories (device, port, route) should not be clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)