### PR TITLE
fix: make pnpm start serve frontend in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "scripts": {
     "dev": "pnpm --filter backend dev & pnpm --filter frontend dev",
     "build": "pnpm --filter frontend build && pnpm --filter backend build",
-    "start": "pnpm --filter backend start"
+    "start": "NODE_ENV=production node backend/dist/index.js"
   }
 }


### PR DESCRIPTION
## Summary

`pnpm start` returned 404s on all non-`/api` routes — the frontend never loaded.

The root `start` script ran `pnpm --filter backend start`, which executes `node dist/index.js` from the `backend/` directory **without** `NODE_ENV` set. The backend only mounts static file serving when `NODE_ENV=production`, and it resolves `./frontend/dist` relative to the cwd. So bare `pnpm start` both skipped static serving entirely *and* would have pointed at the wrong path.

This changes the script to run from the repo root with `NODE_ENV=production`, matching the Dockerfile `CMD` exactly:

```diff
-    "start": "pnpm --filter backend start"
+    "start": "NODE_ENV=production node backend/dist/index.js"
```

## Test plan

- `pnpm start` → `http://localhost:3001/` returns **HTTP 200** with the frontend HTML
- Cache warms and `/api` routes respond as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)