### PR TITLE
feat: IPv6 interface addresses and ND neighbour scraping

### DIFF
--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -724,7 +724,6 @@ export async function pollNdNeighbours() {
   const ndGlobalIpv6 = new Map<string, string[]>();
   // Unmanaged: mac → { ips, vendor, seenByHostname, seenByPort, location }
   const ndUnmanaged = new Map<string, { ips: Set<string>; vendor: string; seenByHostname: string; seenByPort: string; location: string }>();
-  const managedMacs = new Set(macToHostname.keys());
 
   let totalEntries = 0;
 
@@ -744,7 +743,8 @@ export async function pollNdNeighbours() {
         if (!ipv6) continue;
 
         // Only non-link-local, non-loopback addresses provide topology value
-        const isGlobal = !ipv6.startsWith("fe80:") && ipv6 !== "::1";
+        const isGlobal = !ipv6.startsWith("fe80:") && ipv6 !== "::1"
+          && !ipv6.startsWith("fc") && !ipv6.startsWith("fd");
         if (!isGlobal) continue;
 
         if (macToHostname.has(mac)) {
@@ -753,7 +753,7 @@ export async function pollNdNeighbours() {
           const list = ndGlobalIpv6.get(hostname) ?? [];
           if (!list.includes(ipv6)) list.push(ipv6);
           ndGlobalIpv6.set(hostname, list);
-        } else if (!managedMacs.has(mac)) {
+        } else {
           // Unmanaged device visible only via ND
           const existing = ndUnmanaged.get(mac);
           if (existing) {

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -187,7 +187,11 @@ export async function pollPortsAndIps() {
     for (const p of ports) if (p.ifName) currPorts.add(`${hostname}/${p.ifName}`);
   }
   for (const [hostname, ips] of allIps) {
-    for (const ip of ips) if (ip.ipv4_address) currIps.add(`${hostname} ${ip.ipv4_address}`);
+    for (const ip of ips) {
+      if (ip.ipv4_address) currIps.add(`${hostname} ${ip.ipv4_address}`);
+      const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
+      if (v6 && !v6.startsWith("fe80:") && v6 !== "::1") currIps.add(`${hostname} ${v6}`);
+    }
   }
   prevAssets.ports = diffAndLog("port", prevAssets.ports, currPorts);
   prevAssets.ips = diffAndLog("ip", prevAssets.ips, currIps);

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -4,8 +4,8 @@ import { buildOverlayLinks, engine, isExcludedIface, isDockerIp, findLanIp } fro
 import { loadOuiDatabases, lookupVendor, normalizeMac } from "../librenms/oui.js";
 import { makeCidrMatcher } from "../librenms/cidr.js";
 import { ARP_EXCLUDED_SUBNETS, OVERLAY_SUBNET_LIST } from "../config.js";
-import { initWebSession, isWebClientEnabled, fetchRoutes, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
-import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry } from "../librenms/types.js";
+import { initWebSession, isWebClientEnabled, fetchRoutes, fetchNdNeighbours, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
+import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry, LnmsNdEntry } from "../librenms/types.js";
 import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent } from "@librenms-dash/shared";
 
 const STAGGER_MS = 200;
@@ -702,6 +702,111 @@ export async function pollRoutes() {
   flushTopologyChanged();
 }
 
+export async function pollNdNeighbours() {
+  if (!isWebClientEnabled()) return;
+
+  const devices = cache.get<LnmsDevice[]>("devices");
+  if (!devices) return;
+
+  // Build mac → hostname map from cached port data
+  const macToHostname = new Map<string, string>();
+  const hostnameToLocation = new Map<string, string>();
+  for (const d of devices) {
+    hostnameToLocation.set(d.hostname, d.location || "Unknown");
+    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    if (!ports) continue;
+    for (const p of ports) {
+      const mac = normalizeMac(p.ifPhysAddress ?? "");
+      if (mac && mac.length === 12 && mac !== "000000000000") macToHostname.set(mac, d.hostname);
+    }
+  }
+
+  const ndGlobalIpv6 = new Map<string, string[]>();
+  // Unmanaged: mac → { ips, vendor, seenByHostname, seenByPort, location }
+  const ndUnmanaged = new Map<string, { ips: Set<string>; vendor: string; seenByHostname: string; seenByPort: string; location: string }>();
+  const managedMacs = new Set(macToHostname.keys());
+
+  let totalEntries = 0;
+
+  for (const device of devices) {
+    if (device.status !== 1) continue;
+    const location = hostnameToLocation.get(device.hostname) ?? "Unknown";
+
+    try {
+      const entries = await fetchNdNeighbours(device.device_id);
+      if (!isWebClientEnabled()) return;
+      totalEntries += entries.length;
+
+      for (const entry of entries) {
+        const mac = normalizeMac(entry.mac);
+        if (!mac || mac.length !== 12 || mac === "000000000000") continue;
+        const ipv6 = entry.ipv6.trim();
+        if (!ipv6) continue;
+
+        // Only non-link-local, non-loopback addresses provide topology value
+        const isGlobal = !ipv6.startsWith("fe80:") && ipv6 !== "::1";
+        if (!isGlobal) continue;
+
+        if (macToHostname.has(mac)) {
+          // Known managed device — collect its global/ULA IPv6
+          const hostname = macToHostname.get(mac)!;
+          const list = ndGlobalIpv6.get(hostname) ?? [];
+          if (!list.includes(ipv6)) list.push(ipv6);
+          ndGlobalIpv6.set(hostname, list);
+        } else if (!managedMacs.has(mac)) {
+          // Unmanaged device visible only via ND
+          const existing = ndUnmanaged.get(mac);
+          if (existing) {
+            existing.ips.add(ipv6);
+          } else {
+            ndUnmanaged.set(mac, { ips: new Set([ipv6]), vendor: entry.vendor, seenByHostname: device.hostname, seenByPort: entry.portName, location });
+          }
+        }
+      }
+    } catch { /* skip */ }
+    await delay(STAGGER_MS);
+  }
+
+  cache.set("ndGlobalIpv6", ndGlobalIpv6, TTL.PORTS);
+
+  // Merge ND-only unmanaged devices into existing arpDevices
+  const existingArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+  const existingMacSet = new Set(existingArpDevices.map((d) => normalizeMac(d.mac)));
+
+  const ndOnlyDevices: ArpDiscoveredDevice[] = [];
+  for (const [mac, info] of ndUnmanaged) {
+    if (existingMacSet.has(mac)) {
+      // Enrich existing ARP entry with IPv6 addresses
+      const existing = existingArpDevices.find((d) => normalizeMac(d.mac) === mac);
+      if (existing) {
+        for (const ip of info.ips) {
+          if (!existing.ips.includes(ip)) existing.ips.push(ip);
+        }
+      }
+      continue;
+    }
+    const siteId = info.location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    ndOnlyDevices.push({
+      mac,
+      macs: [mac],
+      ips: [...info.ips],
+      vendor: info.vendor || lookupVendor(mac),
+      location: info.location,
+      siteId,
+      seenByHostname: info.seenByHostname,
+      seenByInterface: info.seenByPort,
+      seenByIp: undefined,
+      seenByMac: undefined,
+    });
+  }
+
+  if (ndOnlyDevices.length > 0) {
+    cache.set("arpDevices", [...existingArpDevices, ...ndOnlyDevices], TTL.PORTS);
+  }
+
+  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyDevices.length} ND-only unmanaged devices`);
+}
+
 let prevAlertIds = new Set<number>();
 
 export async function pollAlerts() {
@@ -732,6 +837,7 @@ export async function warmCache() {
   await pollAlerts();
   await pollPortsAndIps();
   await pollRoutes();
+  await pollNdNeighbours();
   console.log("[poller] Cache warm complete");
 }
 
@@ -755,4 +861,5 @@ export function startPoller() {
 
   // Routes: every 5 min (same as ports)
   safeInterval(pollRoutes, TTL.PORTS);
+  safeInterval(pollNdNeighbours, TTL.PORTS);
 }

--- a/backend/src/librenms/types.ts
+++ b/backend/src/librenms/types.ts
@@ -110,6 +110,16 @@ export interface LnmsRoute {
   context_name: string;
 }
 
+export interface LnmsNdEntry {
+  portName: string;
+  portId: number | null;
+  mac: string;
+  vendor: string;
+  ipv6: string;
+  remoteDevice: string;
+  remoteInterface: string;
+}
+
 export interface LnmsListResponse<T> {
   count: number;
   [key: string]: T[] | number | string;

--- a/backend/src/librenms/web-client.ts
+++ b/backend/src/librenms/web-client.ts
@@ -1,5 +1,5 @@
 import { LIBRENMS_URL, LIBRENMS_USER, LIBRENMS_PASS } from "../config.js";
-import type { LnmsRoute } from "./types.js";
+import type { LnmsRoute, LnmsNdEntry } from "./types.js";
 
 let sessionCookie = "";
 let csrfToken = "";
@@ -165,6 +165,78 @@ export async function fetchRoutes(deviceId: number): Promise<LnmsRoute[]> {
 
     const data = await res.json() as { rows?: LnmsRoute[]; total?: number };
     return data.rows ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function parseNdTable(html: string): LnmsNdEntry[] {
+  const macHeaderIdx = html.indexOf('MAC address');
+  if (macHeaderIdx === -1) return [];
+
+  const tableStart = html.lastIndexOf('<table', macHeaderIdx);
+  const tableEnd = html.indexOf('</table>', macHeaderIdx) + '</table>'.length;
+  if (tableStart === -1 || tableEnd < '</table>'.length) return [];
+
+  const tableHtml = html.slice(tableStart, tableEnd);
+  const rowRe = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+  const stripTags = (s: string) => s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+  const results: LnmsNdEntry[] = [];
+  let rowMatch: RegExpExecArray | null;
+  let isFirst = true;
+
+  while ((rowMatch = rowRe.exec(tableHtml)) !== null) {
+    if (isFirst) { isFirst = false; continue; } // skip header
+
+    const cells: string[] = [];
+    let cellMatch: RegExpExecArray | null;
+    cellRe.lastIndex = 0;
+    while ((cellMatch = cellRe.exec(rowMatch[1])) !== null) cells.push(cellMatch[1]);
+    if (cells.length < 4) continue;
+
+    const portHref = cells[0].match(/href="[^"]+\/port=(\d+)\/[^"]*"[^>]*>\s*([A-Za-z0-9._\-/]+)/);
+    const portName = portHref ? portHref[2].trim() : stripTags(cells[0]).split(' ')[0];
+    const portId = portHref ? parseInt(portHref[1], 10) : null;
+
+    const mac = stripTags(cells[1]);
+    const vendor = stripTags(cells[2]);
+    const ipv6 = stripTags(cells[3]);
+    if (!mac || !ipv6) continue;
+
+    const remoteDevMatch = cells[4]?.match(/href="[^"]*device=\d+[^"]*"[^>]*>\s*([^\n<]{1,60})/);
+    const remoteDevice = remoteDevMatch ? remoteDevMatch[1].trim() : '';
+
+    const remoteIfaceMatch = cells[5]?.match(/href="[^"]+\/port=\d+\/[^"]*"[^>]*>\s*([A-Za-z0-9._\-/]+)/);
+    const remoteInterface = remoteIfaceMatch ? remoteIfaceMatch[1].trim() : '';
+
+    results.push({ portName, portId, mac, vendor, ipv6, remoteDevice, remoteInterface });
+  }
+
+  return results;
+}
+
+export async function fetchNdNeighbours(deviceId: number): Promise<LnmsNdEntry[]> {
+  if (disabled) return [];
+
+  const path = `/device/${deviceId}/ports/nd`;
+
+  try {
+    let res = await webFetch(path);
+
+    if (res.status === 401 || res.status === 302 || res.status === 419) {
+      const ok = await login();
+      if (!ok) {
+        console.log("[web-client] ND polling disabled — re-authentication failed");
+        disabled = true;
+        return [];
+      }
+      res = await webFetch(path);
+    }
+
+    if (!res.ok) return [];
+    return parseNdTable(await res.text());
   } catch {
     return [];
   }

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -53,10 +53,14 @@ app.get("/:hostname/overview", async (c) => {
 
   const ipsByPort = new Map<number, string[]>();
   for (const ip of ips) {
-    if (!ip.ipv4_address) continue;
+    const addrs: string[] = [];
+    if (ip.ipv4_address) addrs.push(ip.ipv4_address);
+    const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
+    if (v6) addrs.push(v6);
+    if (addrs.length === 0) continue;
     const arr = ipsByPort.get(ip.port_id);
-    if (arr) arr.push(ip.ipv4_address);
-    else ipsByPort.set(ip.port_id, [ip.ipv4_address]);
+    if (arr) for (const a of addrs) arr.push(a);
+    else ipsByPort.set(ip.port_id, addrs);
   }
 
   const dockerVethRe = /^br-[a-f0-9]{12}$|^docker0$|^veth[a-f0-9]+$/;

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -54,7 +54,7 @@ app.get("/:hostname/overview", async (c) => {
   const ipsByPort = new Map<number, string[]>();
   for (const ip of ips) {
     const addrs: string[] = [];
-    if (ip.ipv4_address) addrs.push(ip.ipv4_address);
+    if (ip.ipv4_address && !engine.isOverlayIp(ip.ipv4_address)) addrs.push(ip.ipv4_address);
     const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
     if (v6) addrs.push(v6);
     if (addrs.length === 0) continue;
@@ -75,7 +75,7 @@ app.get("/:hostname/overview", async (c) => {
     .filter((iface) => iface.mac && iface.mac !== "00:00:00:00:00:00");
 
   const deviceIps = findDeviceIps(ips, ports);
-  if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+  if (device.ip && !deviceIps.includes(device.ip) && !engine.isOverlayIp(device.ip)) deviceIps.push(device.ip);
   const arpLanIps = cache.get<Map<string, string>>("arpLanIps");
   const arpLanIp = arpLanIps?.get(hostname);
   if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -79,6 +79,10 @@ app.get("/:hostname/overview", async (c) => {
   const arpLanIps = cache.get<Map<string, string>>("arpLanIps");
   const arpLanIp = arpLanIps?.get(hostname);
   if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+  const ndGlobalIpv6 = cache.get<Map<string, string[]>>("ndGlobalIpv6");
+  for (const v6 of ndGlobalIpv6?.get(hostname) ?? []) {
+    if (!deviceIps.includes(v6)) deviceIps.push(v6);
+  }
 
   const overview: DeviceOverview = {
     device: {

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -54,7 +54,7 @@ app.get("/:hostname/overview", async (c) => {
   const ipsByPort = new Map<number, string[]>();
   for (const ip of ips) {
     const addrs: string[] = [];
-    if (ip.ipv4_address && !engine.isOverlayIp(ip.ipv4_address)) addrs.push(ip.ipv4_address);
+    if (ip.ipv4_address) addrs.push(ip.ipv4_address);
     const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
     if (v6) addrs.push(v6);
     if (addrs.length === 0) continue;

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -61,6 +61,15 @@ app.get("/", (c) => {
     const deviceIps = findDeviceIps(ips, ports);
     if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
     const arpLanIp = arpLanIps.get(device.hostname);
+
+    // All addresses for search — includes link-local, ULA, and loopback IPv6
+    const allIpsSet = new Set<string>(deviceIps);
+    for (const entry of ips) {
+      if (entry.ipv4_address) allIpsSet.add(entry.ipv4_address);
+      const v6 = entry.ipv6_compressed ?? entry.ipv6_address;
+      if (v6) allIpsSet.add(v6);
+    }
+    if (device.ip) allIpsSet.add(device.ip);
     if (arpLanIp && engine.isOverlayIp(lanIp)) lanIp = arpLanIp;
     if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
 
@@ -71,6 +80,7 @@ app.get("/", (c) => {
       ip: device.ip,
       lanIp,
       ips: deviceIps,
+      allIps: [...allIpsSet],
       macs: [...macSet],
       os: device.os,
       icon: device.icon,

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -70,6 +70,15 @@ app.get("/", (c) => {
       if (v6) allIpsSet.add(v6);
     }
     if (device.ip) allIpsSet.add(device.ip);
+
+    // ND-scraped global IPv6 for this device (not available via REST API)
+    const ndGlobalIpv6 = cache.get<Map<string, string[]>>("ndGlobalIpv6");
+    const deviceNdV6 = ndGlobalIpv6?.get(device.hostname) ?? [];
+    for (const v6 of deviceNdV6) {
+      if (!deviceIps.includes(v6)) deviceIps.push(v6);
+      allIpsSet.add(v6);
+    }
+
     if (arpLanIp && engine.isOverlayIp(lanIp)) lanIp = arpLanIp;
     if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
 

--- a/backend/src/routes/topology.ts
+++ b/backend/src/routes/topology.ts
@@ -59,7 +59,7 @@ app.get("/", (c) => {
 
     let lanIp = findLanIp(device.ip, ips, ports);
     const deviceIps = findDeviceIps(ips, ports);
-    if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+    if (device.ip && !deviceIps.includes(device.ip) && !engine.isOverlayIp(device.ip)) deviceIps.push(device.ip);
     const arpLanIp = arpLanIps.get(device.hostname);
 
     // All addresses for search — includes link-local, ULA, and loopback IPv6

--- a/docs/arp-deduplication-and-correlation.md
+++ b/docs/arp-deduplication-and-correlation.md
@@ -1,0 +1,211 @@
+# ARP Deduplication and Correlation Design
+
+This document describes how the backend resolves, deduplicates, and correlates managed devices, ARP-discovered (unmanaged) devices, and the links between them.
+
+## Overview
+
+The pipeline runs inside `pollArpLinks` (called from `pollPortsAndIps`) and `consolidateArpDevices`. It produces three outputs cached for the topology response:
+
+| Cache key       | Type                    | Contents                                              |
+|-----------------|-------------------------|-------------------------------------------------------|
+| `arpLinks`      | `ArpLink[]`             | Peer relationships between two managed devices        |
+| `arpDevices`    | `ArpDiscoveredDevice[]` | Consolidated unmanaged devices seen in ARP tables     |
+| `arpLanIps`     | `Map<string, string>`   | LAN IP override for managed devices polled via overlay |
+
+---
+
+## Stage 0 — Managed Device Filtering
+
+**File:** `backend/src/jobs/poller.ts` → `pollDevicesAndLocations`
+
+- Devices with `disabled === 1` are excluded from the active set before caching.
+- They are still stored separately under `allDevicesForExclusion`. This ensures their IPs and interface MACs are always included in the managed exclusion sets, preventing them from re-appearing as unmanaged discovered devices.
+
+---
+
+## Stage 1 — Exclusion Set Construction
+
+Before any ARP analysis, two per-location exclusion sets are built so that managed infrastructure is never treated as an unmanaged discovered device.
+
+### 1a — Managed IPs by location (`managedIpsByLocation`)
+
+For every device in `allDevicesForExclusion`:
+- Add `device.ip`
+- Add every `ipv4_address` from that device's cached `/ip` response
+
+Scoped per location because LAN subnets can overlap across sites (e.g. `192.168.1.0/24` at both BLR and GGN are physically separate networks).
+
+### 1b — Managed MACs by location (`managedMacsByLocation`)
+
+Two sub-steps:
+
+1. **ARP-derived:** Walk all collected ARP entries. If an entry's IP matches a managed IP at that location, add its normalized MAC to the location's set.
+2. **Interface-derived:** For every device in `allDevicesForExclusion`, add all `ifPhysAddress` values from its port cache. This ensures a managed device's own interfaces never appear as ghost discovered devices, even if their IP endpoint fails or returns an overlay address.
+
+---
+
+## Stage 2 — ARP Link Building (Managed ↔ Managed)
+
+**File:** `backend/src/jobs/poller.ts` → `pollArpLinks`
+
+Links represent peer visibility between two managed devices on the same physical LAN.
+
+### Pass 1 — IP-based matching
+
+For each unique local IP owned by a managed device:
+1. Fetch `/resources/ip/arp/<ip>` from LibreNMS.
+2. For each ARP entry returned, look up `entry.device_id` → `seeingHostname`.
+3. If `seeingHostname` differs from the IP owner and both are in the same location, a link candidate exists.
+4. Deduplicate using a canonical key: `[ownerHostname, seeingHostname].sort().join("<>")`. Bidirectional duplicates (A sees B, B sees A) collapse into one link.
+
+### Pass 2 — MAC-based matching
+
+Catches managed devices whose `/ip` endpoint fails or 404s. For each ARP entry across the full corpus:
+1. Normalize `entry.mac_address` and look it up in `macToHostname` (built from interface MACs of all active devices).
+2. If the MAC owner differs from the seer and they share a location, create a link.
+3. Use the same `linkSet` as Pass 1 — no duplicate is added if Pass 1 already covered the pair.
+
+### Exclusions (both passes)
+
+| Exclusion | Reason |
+|-----------|--------|
+| Overlay/VPN IPs (`isExcludedArpIp`) | ZeroTier, WireGuard, etc. are logical, not physical |
+| Docker bridge IPs (`isDockerIp`) | Container-internal traffic |
+| Excluded interfaces (`isExcludedIface`) | Loopback, `docker0`, overlay tunnels |
+| Cross-location pairs | LAN subnets overlap; cross-site ARP is not meaningful |
+
+---
+
+## Stage 3 — ARP Discovered Device Consolidation
+
+**File:** `backend/src/jobs/poller.ts` → `consolidateArpDevices`
+
+Unmanaged devices (not in LibreNMS) that appear in ARP tables are consolidated into deduplicated `ArpDiscoveredDevice` records. The key challenge is that a single physical device may appear under multiple MACs (e.g. two NICs) or multiple IPs (DHCP churn, dual-stack aliases), observed by several scanners.
+
+### Phase 1 — Valid pair collection
+
+Walk all ARP entries. For each entry, a `(mac, ip)` pair is accepted only if:
+
+- Source `device_id` belongs to an active (non-disabled) device
+- MAC is not `000000000000`, `FFFFFFFFFFFF`
+- MAC passes the bogus-pattern check (no all-zero suffix, no all-same-byte pattern)
+- IP is not `0.0.0.0`
+- IP is not in an overlay or excluded subnet
+- Interface is not excluded (`isExcludedIface`)
+- Neither the IP nor the MAC appears in the managed exclusion sets for that location
+
+Pairs are scoped to a location. Exact `(location, mac, ip)` duplicates are collapsed immediately.
+
+### Phase 2 — Union-Find merging
+
+Within each location, a path-compressed union-find merges entries that share a MAC **or** an IP:
+
+```
+Keys: "mac:<normalized-hex>" and "ip:<addr>"
+Rule: union(mac-key, ip-key) for every (mac, ip) pair
+```
+
+This handles:
+- Same device seen at two IPs → both IPs end up in one component
+- Same IP observed with two different MACs → both MACs merge into one component
+- Transitive chains: MAC₁ ↔ IP₁ ↔ MAC₂ → single device with two MACs and one IP
+
+Merging is **location-scoped** to prevent cross-site false merges from overlapping subnets.
+
+### Phase 3 — Component grouping
+
+After union-find, entries are grouped by their root node. Each component accumulates:
+- `macs: Set<string>` — all normalized MACs in the component
+- `ips: Set<string>` — all IPs in the component
+- `deviceId` / `portId` from the first pair that formed the component (used for `seenBy*` metadata)
+
+### Phase 4 — Representative MAC selection
+
+One `ArpDiscoveredDevice` is emitted per component. The best MAC is chosen by:
+
+1. **Prefer globally-administered over locally-administered** (bit 1 of first byte unset = OUI-registered hardware address)
+2. **Among globals, prefer MACs with a known OUI vendor** (via OUI database lookup)
+
+IPs are sorted numerically. Output fields:
+
+| Field              | Source                                                    |
+|--------------------|-----------------------------------------------------------|
+| `mac`              | Best MAC (above selection)                                |
+| `macs`             | All MACs in component                                     |
+| `ips`              | All IPs in component, numerically sorted                  |
+| `vendor`           | OUI lookup on best MAC                                    |
+| `location`         | Site name                                                 |
+| `siteId`           | URL-safe slug of location                                 |
+| `seenByHostname`   | Managed device that first observed this component         |
+| `seenByInterface`  | Interface name on the seer (`portIdToIfName`)             |
+| `seenByIp`         | Local IP of the seer's port (`portIdToIp`)                |
+| `seenByMac`        | MAC of the seer's port (`portIdToMac`)                    |
+
+---
+
+## Stage 4 — ARP LAN IP Discovery
+
+**File:** `backend/src/jobs/poller.ts` → `pollArpLinks` (after consolidation)
+
+Managed devices polled exclusively via overlay (VPN) may have no usable LAN IP in their `/ip` response. To resolve this:
+
+1. Scan all ARP entries for MACs that match a managed device's interface MAC (`macToHostname`).
+2. If the associated IP is not an overlay, docker-bridge, or excluded subnet IP, record it as that device's LAN IP in `arpLanIps`.
+
+**Used in:** `topology.ts:63–65` — if a managed device's computed `lanIp` falls in an overlay range, it is replaced with the ARP-discovered LAN IP.
+
+---
+
+## LLDP/CDP Neighbor Link Deduplication
+
+**File:** `backend/src/routes/topology.ts:104–131`
+
+Neighbor links from LibreNMS's LLDP/CDP data are deduplicated using a canonical key:
+
+```
+key = [local_device_id, remote_device_id].sort().join("-")
+    + ":" + [local_port_id, remote_port_id].sort().join("-")
+```
+
+This collapses A→B and B→A entries for the same physical port pair into a single `NeighborLink`. Excluded interfaces are filtered before the key is computed.
+
+---
+
+## Data Flow Summary
+
+```
+LibreNMS API
+    │
+    ├─ /devices              → active devices + allDevicesForExclusion
+    ├─ /devices/:h/ports     → ports, MACs, traffic rates
+    ├─ /devices/:h/ip        → IP assignments
+    ├─ /resources/ip/arp/:ip → ARP table per managed IP   ─┐
+    └─ /resources/ip/arp/all → full ARP corpus            ─┘
+                                                            │
+                                          ┌─────────────────▼──────────────────┐
+                                          │  Stage 1: Build exclusion sets      │
+                                          │  (managedIpsByLocation,             │
+                                          │   managedMacsByLocation)            │
+                                          └─────────────────┬──────────────────┘
+                                                            │
+                                          ┌─────────────────▼──────────────────┐
+                                          │  Stage 2: ARP link building         │
+                                          │  Pass 1 (IP-based) +               │
+                                          │  Pass 2 (MAC-based fallback)        │
+                                          │  → arpLinks[]                       │
+                                          └─────────────────┬──────────────────┘
+                                                            │
+                                          ┌─────────────────▼──────────────────┐
+                                          │  Stage 3: Consolidate discovered    │
+                                          │  Phase 1: filter pairs              │
+                                          │  Phase 2: union-find per location   │
+                                          │  Phase 3: group by component        │
+                                          │  Phase 4: pick best MAC             │
+                                          │  → arpDevices[]                     │
+                                          └─────────────────┬──────────────────┘
+                                                            │
+                                          ┌─────────────────▼──────────────────┐
+                                          │  Stage 4: ARP LAN IP discovery      │
+                                          │  → arpLanIps (Map<hostname, ip>)    │
+                                          └────────────────────────────────────┘
+```

--- a/docs/superpowers/plans/2026-06-27-ipv6-interface-addresses.md
+++ b/docs/superpowers/plans/2026-06-27-ipv6-interface-addresses.md
@@ -1,0 +1,225 @@
+# IPv6 Interface Addresses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface IPv6 addresses from the existing LibreNMS per-device IP endpoint into the topology device summaries, device detail interface list, and asset change-detection events.
+
+**Architecture:** Three surgical edits across two backend files and one frontend component. No new API calls, no new cache keys, no type changes. The `findDeviceIps()` function and `DeviceSummary.ips[]` pipeline already handle IPv6 correctly; these tasks close the two remaining gaps and fix the frontend display width.
+
+**Tech Stack:** TypeScript (Bun runtime), Hono, React + Tailwind, Docker Compose.
+
+## Global Constraints
+
+- Verify all changes with `docker-compose up -d --build` — not bare `tsc`.
+- Do not add imports not already used elsewhere in the file.
+- Do not modify `shared/types.ts`, `overlays.ts`, or any frontend file other than `DevicePopover.tsx`.
+- Match existing code style exactly (no trailing commas where absent, same indent).
+
+---
+
+### Task 1: Add IPv6 to per-interface IP list in device overview
+
+**Files:**
+- Modify: `backend/src/routes/devices.ts:52-59`
+
+**Context:** The `/overview` handler builds an `ipsByPort` map (`Map<number, string[]>`) that drives `DeviceInterface.ips[]` — the per-interface IP list shown in the device detail popover. It currently only reads `ip.ipv4_address`. `LnmsDeviceIp` already has optional `ipv6_compressed` and `ipv6_address` fields populated when LibreNMS has IPv6 data for that port.
+
+**Interfaces:**
+- Consumes: `LnmsDeviceIp` (fields: `port_id: number`, `ipv4_address: string`, `ipv6_compressed?: string`, `ipv6_address?: string`)
+- Produces: `ipsByPort: Map<number, string[]>` — now contains both IPv4 and IPv6 addresses per port
+
+- [ ] **Step 1: Locate the ipsByPort loop**
+
+Open `backend/src/routes/devices.ts`. Find lines 52–59:
+
+```typescript
+  const ipsByPort = new Map<number, string[]>();
+  for (const ip of ips) {
+    if (!ip.ipv4_address) continue;
+    const arr = ipsByPort.get(ip.port_id);
+    if (arr) arr.push(ip.ipv4_address);
+    else ipsByPort.set(ip.port_id, [ip.ipv4_address]);
+  }
+```
+
+- [ ] **Step 2: Replace the loop to include IPv6**
+
+Replace those 7 lines with:
+
+```typescript
+  const ipsByPort = new Map<number, string[]>();
+  for (const ip of ips) {
+    const addrs: string[] = [];
+    if (ip.ipv4_address) addrs.push(ip.ipv4_address);
+    const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
+    if (v6) addrs.push(v6);
+    if (addrs.length === 0) continue;
+    const arr = ipsByPort.get(ip.port_id);
+    if (arr) for (const a of addrs) arr.push(a);
+    else ipsByPort.set(ip.port_id, addrs);
+  }
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd backend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/routes/devices.ts
+git commit -m "feat: include IPv6 addresses in per-interface IP list"
+```
+
+---
+
+### Task 2: Add IPv6 to asset change-detection set
+
+**Files:**
+- Modify: `backend/src/jobs/poller.ts:189-191`
+
+**Context:** `pollPortsAndIps` builds `currIps` — a `Set<string>` of `"hostname addr"` strings — and diffs it against `prevAssets.ips` to emit add/remove asset events. Currently it only tracks `ipv4_address`. IPv6 addresses silently appear and disappear.
+
+**Interfaces:**
+- Consumes: `allIps: Map<string, LnmsDeviceIp[]>` (populated earlier in same function)
+- Produces: `currIps: Set<string>` — now includes IPv6 entries in the form `"hostname addr"`
+
+- [ ] **Step 1: Locate the currIps loop**
+
+Open `backend/src/jobs/poller.ts`. Find lines ~189-191:
+
+```typescript
+  for (const [hostname, ips] of allIps) {
+    for (const ip of ips) if (ip.ipv4_address) currIps.add(`${hostname} ${ip.ipv4_address}`);
+  }
+```
+
+- [ ] **Step 2: Replace to include IPv6**
+
+Replace those 3 lines with:
+
+```typescript
+  for (const [hostname, ips] of allIps) {
+    for (const ip of ips) {
+      if (ip.ipv4_address) currIps.add(`${hostname} ${ip.ipv4_address}`);
+      const v6 = ip.ipv6_compressed ?? ip.ipv6_address;
+      if (v6 && !v6.startsWith("fe80:") && v6 !== "::1") currIps.add(`${hostname} ${v6}`);
+    }
+  }
+```
+
+The `fe80:` and `::1` guards prevent link-local and loopback churn from generating spurious add/remove events on every poll cycle.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd backend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/jobs/poller.ts
+git commit -m "feat: track IPv6 addresses in asset change-detection"
+```
+
+---
+
+### Task 3: Truncate IPv6 in the interface table with copy-on-click
+
+**Files:**
+- Modify: `frontend/src/components/DevicePopover.tsx:287-295`
+
+**Context:** The interfaces table shows one row per interface with columns: Name, MAC, IPs. Each IP is rendered as `<Copyable text={ip}>{ip}</Copyable>` inside a `<div>`. Without `block` on `<Copyable>`, the span is `inline` and does not truncate. IPv6 addresses (up to 39 chars) widen the entire table.
+
+`Copyable` already has `title={text}` (hover shows full address) and applies `block truncate` when the `block` prop is passed. Adding `overflow-hidden` to the `<td>` ensures `truncate` activates correctly in table layout.
+
+**Interfaces:**
+- Consumes: `iface.ips: string[]` — array of IPv4 and/or IPv6 address strings
+- Produces: visual truncation in the IPs column; hover tooltip shows full address; click copies full address
+
+- [ ] **Step 1: Locate the IPs td in the interfaces table**
+
+Open `frontend/src/components/DevicePopover.tsx`. Find lines ~287-295:
+
+```tsx
+                      <td className="py-0.5 px-2 font-mono text-gray-300">
+                        {iface.ips.length > 0
+                          ? iface.ips.map((ip) => (
+                              <div key={ip} className="leading-tight">
+                                <Copyable text={ip}>{ip}</Copyable>
+                              </div>
+                            ))
+                          : "—"}
+                      </td>
+```
+
+- [ ] **Step 2: Add overflow-hidden to the td and block prop to Copyable**
+
+Replace those 9 lines with:
+
+```tsx
+                      <td className="py-0.5 px-2 font-mono text-gray-300 overflow-hidden">
+                        {iface.ips.length > 0
+                          ? iface.ips.map((ip) => (
+                              <div key={ip} className="leading-tight">
+                                <Copyable text={ip} block>{ip}</Copyable>
+                              </div>
+                            ))
+                          : "—"}
+                      </td>
+```
+
+The only changes are: `overflow-hidden` added to `<td>` className, and `block` prop added to `<Copyable>`. `Copyable` with `block` renders as `display:block; overflow:hidden; text-overflow:ellipsis`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/DevicePopover.tsx
+git commit -m "feat: truncate IPv6 in interface table, copy-on-click preserved"
+```
+
+---
+
+### Task 4: Build and verify
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and start containers**
+
+```bash
+docker-compose up -d --build
+```
+
+Expected: build succeeds, both `backend` and `frontend` containers start without errors. Check with:
+
+```bash
+docker-compose logs --tail=30
+```
+
+Expected: `[librenms-dash] Cache warm complete` in backend logs, no TypeScript or React build errors.
+
+- [ ] **Step 2: Visual check — device IP rows**
+
+Open the dashboard. Click any device with known IPv6 on its interfaces. In the device popover:
+- The main IP rows should show IPv6 addresses (e.g. `2001:db8::1`) alongside IPv4.
+- Long IPv6 strings should be truncated with `…` — hovering shows the full address.
+- Clicking an IPv6 address copies it (text turns green briefly).
+
+- [ ] **Step 3: Visual check — interface table**
+
+Scroll to the Interfaces section of the same popover:
+- The IPs column should show both IPv4 and IPv6 for dual-stack interfaces.
+- IPv6 is truncated to fit the column width — no table widening.
+- Hovering an IPv6 cell shows the full address in the browser tooltip.
+- Clicking copies the full address.
+
+- [ ] **Step 4: Check asset change log (optional)**
+
+In the dashboard asset event log, restart the backend and wait for the first full poll. If any device has IPv6 addresses, you should see `ip added: hostname 2001:...` events on first run (baseline), then silence on subsequent polls.

--- a/docs/superpowers/plans/2026-06-27-ipv6-nd-web-scrape.md
+++ b/docs/superpowers/plans/2026-06-27-ipv6-nd-web-scrape.md
@@ -1,0 +1,498 @@
+# IPv6 ND Web Scrape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scrape `/device/{id}/ports/nd` from the LibreNMS web UI per device, extract global IPv6 addresses, enrich managed device IP lists, and surface IPv6-only unmanaged devices alongside ARP-discovered ones.
+
+**Architecture:** A new `fetchNdNeighbours(deviceId)` function added to the existing `web-client.ts` (same session + re-login pattern as `fetchRoutes`). A new `pollNdNeighbours()` in `poller.ts` builds two caches: `ndGlobalIpv6` (hostname → global IPv6[]) for managed device enrichment, and appends ND-only unmanaged MACs into the existing `arpDevices` cache. The topology and device-overview routes read `ndGlobalIpv6` to inject IPv6 into `DeviceSummary.ips[]`, `allIps[]`, and `Device.ips[]`.
+
+**Tech Stack:** TypeScript, Hono, regex HTML parsing (no DOM library — same approach as existing route scraper), Docker Compose for verification.
+
+## Global Constraints
+
+- Verify all changes with `docker-compose up -d --build` — not bare `tsc`.
+- No new npm dependencies — parse HTML with regex, same as existing `web-client.ts`.
+- Follow existing stagger pattern: `await delay(STAGGER_MS)` between per-device requests.
+- Guard every `fetchNdNeighbours` call with `if (!isWebClientEnabled()) return` — ND polling is silently disabled when web credentials are absent, identical to route polling.
+- Do not modify `shared/types.ts` — reuse `ArpDiscoveredDevice` for ND-only unmanaged devices.
+- Match existing code style exactly.
+
+---
+
+### Task 1: Add `LnmsNdEntry` type and `fetchNdNeighbours` to web-client
+
+**Files:**
+- Modify: `backend/src/librenms/types.ts` — append `LnmsNdEntry` interface
+- Modify: `backend/src/librenms/web-client.ts` — append `parseNdTable` + `fetchNdNeighbours`
+
+**Interfaces:**
+- Produces:
+  - `LnmsNdEntry` (in `types.ts`): `{ portName: string; portId: number | null; mac: string; vendor: string; ipv6: string; remoteDevice: string; remoteInterface: string }`
+  - `fetchNdNeighbours(deviceId: number): Promise<LnmsNdEntry[]>` (exported from `web-client.ts`)
+
+- [ ] **Step 1: Add `LnmsNdEntry` to `backend/src/librenms/types.ts`**
+
+Append after the closing brace of `LnmsRoute` (around line 111):
+
+```typescript
+export interface LnmsNdEntry {
+  portName: string;
+  portId: number | null;
+  mac: string;
+  vendor: string;
+  ipv6: string;
+  remoteDevice: string;
+  remoteInterface: string;
+}
+```
+
+- [ ] **Step 2: Add `parseNdTable` and `fetchNdNeighbours` to `backend/src/librenms/web-client.ts`**
+
+Add the import of `LnmsNdEntry` at the top of `web-client.ts` — change line 2 from:
+```typescript
+import type { LnmsRoute } from "./types.js";
+```
+to:
+```typescript
+import type { LnmsRoute, LnmsNdEntry } from "./types.js";
+```
+
+Then append the following two functions before the final `export { extractIfaceName, extractNextHop, stripHtml };` line:
+
+```typescript
+function parseNdTable(html: string): LnmsNdEntry[] {
+  const macHeaderIdx = html.indexOf('MAC address');
+  if (macHeaderIdx === -1) return [];
+
+  const tableStart = html.lastIndexOf('<table', macHeaderIdx);
+  const tableEnd = html.indexOf('</table>', macHeaderIdx) + '</table>'.length;
+  if (tableStart === -1 || tableEnd < '</table>'.length) return [];
+
+  const tableHtml = html.slice(tableStart, tableEnd);
+  const rowRe = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+  const stripTags = (s: string) => s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+  const results: LnmsNdEntry[] = [];
+  let rowMatch: RegExpExecArray | null;
+  let isFirst = true;
+
+  while ((rowMatch = rowRe.exec(tableHtml)) !== null) {
+    if (isFirst) { isFirst = false; continue; } // skip header
+
+    const cells: string[] = [];
+    let cellMatch: RegExpExecArray | null;
+    cellRe.lastIndex = 0;
+    while ((cellMatch = cellRe.exec(rowMatch[1])) !== null) cells.push(cellMatch[1]);
+    if (cells.length < 4) continue;
+
+    const portHref = cells[0].match(/href="[^"]+\/port=(\d+)\/[^"]*"[^>]*>\s*([A-Za-z0-9._\-/]+)/);
+    const portName = portHref ? portHref[2].trim() : stripTags(cells[0]).split(' ')[0];
+    const portId = portHref ? parseInt(portHref[1], 10) : null;
+
+    const mac = stripTags(cells[1]);
+    const vendor = stripTags(cells[2]);
+    const ipv6 = stripTags(cells[3]);
+    if (!mac || !ipv6) continue;
+
+    const remoteDevMatch = cells[4]?.match(/href="[^"]*device=\d+[^"]*"[^>]*>\s*([^\n<]{1,60})/);
+    const remoteDevice = remoteDevMatch ? remoteDevMatch[1].trim() : '';
+
+    const remoteIfaceMatch = cells[5]?.match(/href="[^"]+\/port=\d+\/[^"]*"[^>]*>\s*([A-Za-z0-9._\-/]+)/);
+    const remoteInterface = remoteIfaceMatch ? remoteIfaceMatch[1].trim() : '';
+
+    results.push({ portName, portId, mac, vendor, ipv6, remoteDevice, remoteInterface });
+  }
+
+  return results;
+}
+
+export async function fetchNdNeighbours(deviceId: number): Promise<LnmsNdEntry[]> {
+  if (disabled) return [];
+
+  const path = `/device/${deviceId}/ports/nd`;
+
+  try {
+    let res = await webFetch(path);
+
+    if (res.status === 401 || res.status === 302 || res.status === 419) {
+      const ok = await login();
+      if (!ok) {
+        console.log("[web-client] ND polling disabled — re-authentication failed");
+        disabled = true;
+        return [];
+      }
+      res = await webFetch(path);
+    }
+
+    if (!res.ok) return [];
+    return parseNdTable(await res.text());
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd /home/jkumar/Librenms-dash/backend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/librenms/types.ts backend/src/librenms/web-client.ts
+git commit -m "feat: add LnmsNdEntry type and fetchNdNeighbours HTML scraper"
+```
+
+---
+
+### Task 2: Add `pollNdNeighbours` to poller and wire it up
+
+**Files:**
+- Modify: `backend/src/jobs/poller.ts`
+
+**Interfaces:**
+- Consumes:
+  - `fetchNdNeighbours(deviceId: number): Promise<LnmsNdEntry[]>` from `web-client.ts`
+  - `LnmsNdEntry` from `types.ts`
+  - `normalizeMac(mac: string): string` from `oui.ts` (already imported)
+  - `lookupVendor(mac: string): string` from `oui.ts` (already imported)
+  - `isWebClientEnabled(): boolean` from `web-client.ts` (already imported)
+  - `delay(ms: number)` from `client.ts` (already imported)
+  - `STAGGER_MS` constant (already defined at top of file, value `200`)
+  - `TTL` from `cache/store.ts` (already imported) — use `TTL.PORTS`
+  - `ArpDiscoveredDevice` from `@librenms-dash/shared` (already imported)
+- Produces:
+  - Cache key `"ndGlobalIpv6"` → `Map<string, string[]>` (hostname → global IPv6 addresses)
+  - Enriched `"arpDevices"` cache entry — ND-only unmanaged MACs appended
+
+- [ ] **Step 1: Add `LnmsNdEntry` to the type import at the top of `poller.ts`**
+
+Find line 8 (the `import type { LnmsDevice, ... }` line):
+```typescript
+import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry } from "../librenms/types.js";
+```
+Replace with:
+```typescript
+import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry, LnmsNdEntry } from "../librenms/types.js";
+```
+
+- [ ] **Step 2: Add `fetchNdNeighbours` to the web-client import**
+
+Find line 7 (the `import { initWebSession, ... }` line):
+```typescript
+import { initWebSession, isWebClientEnabled, fetchRoutes, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
+```
+Replace with:
+```typescript
+import { initWebSession, isWebClientEnabled, fetchRoutes, fetchNdNeighbours, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
+```
+
+- [ ] **Step 3: Add `pollNdNeighbours` function**
+
+Add this function after `pollRoutes` (around line 699, before the `let prevAlertIds` line):
+
+```typescript
+export async function pollNdNeighbours() {
+  if (!isWebClientEnabled()) return;
+
+  const devices = cache.get<LnmsDevice[]>("devices");
+  if (!devices) return;
+
+  // Build mac → hostname map from cached port data
+  const macToHostname = new Map<string, string>();
+  const hostnameToLocation = new Map<string, string>();
+  for (const d of devices) {
+    hostnameToLocation.set(d.hostname, d.location || "Unknown");
+    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    if (!ports) continue;
+    for (const p of ports) {
+      const mac = normalizeMac(p.ifPhysAddress ?? "");
+      if (mac && mac.length === 12 && mac !== "000000000000") macToHostname.set(mac, d.hostname);
+    }
+  }
+
+  const ndGlobalIpv6 = new Map<string, string[]>();
+  // Unmanaged: mac → { ips, vendor, seenByHostname, seenByPort, location }
+  const ndUnmanaged = new Map<string, { ips: Set<string>; vendor: string; seenByHostname: string; seenByPort: string; location: string }>();
+  const managedMacs = new Set(macToHostname.keys());
+
+  let totalEntries = 0;
+
+  for (const device of devices) {
+    if (device.status !== 1) continue;
+    const location = hostnameToLocation.get(device.hostname) ?? "Unknown";
+
+    try {
+      const entries = await fetchNdNeighbours(device.device_id);
+      if (!isWebClientEnabled()) return;
+      totalEntries += entries.length;
+
+      for (const entry of entries) {
+        const mac = normalizeMac(entry.mac);
+        if (!mac || mac.length !== 12 || mac === "000000000000") continue;
+        const ipv6 = entry.ipv6.trim();
+        if (!ipv6) continue;
+
+        // Only non-link-local, non-loopback addresses provide topology value
+        const isGlobal = !ipv6.startsWith("fe80:") && ipv6 !== "::1";
+        if (!isGlobal) continue;
+
+        if (macToHostname.has(mac)) {
+          // Known managed device — collect its global/ULA IPv6
+          const hostname = macToHostname.get(mac)!;
+          const list = ndGlobalIpv6.get(hostname) ?? [];
+          if (!list.includes(ipv6)) list.push(ipv6);
+          ndGlobalIpv6.set(hostname, list);
+        } else if (!managedMacs.has(mac)) {
+          // Unmanaged device visible only via ND
+          const existing = ndUnmanaged.get(mac);
+          if (existing) {
+            existing.ips.add(ipv6);
+          } else {
+            ndUnmanaged.set(mac, { ips: new Set([ipv6]), vendor: entry.vendor, seenByHostname: device.hostname, seenByPort: entry.portName, location });
+          }
+        }
+      }
+    } catch { /* skip */ }
+    await delay(STAGGER_MS);
+  }
+
+  cache.set("ndGlobalIpv6", ndGlobalIpv6, TTL.PORTS);
+
+  // Merge ND-only unmanaged devices into existing arpDevices
+  const existingArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+  const existingMacSet = new Set(existingArpDevices.map((d) => normalizeMac(d.mac)));
+
+  const ndOnlyDevices: ArpDiscoveredDevice[] = [];
+  for (const [mac, info] of ndUnmanaged) {
+    if (existingMacSet.has(mac)) {
+      // Enrich existing ARP entry with IPv6 addresses
+      const existing = existingArpDevices.find((d) => normalizeMac(d.mac) === mac);
+      if (existing) {
+        for (const ip of info.ips) {
+          if (!existing.ips.includes(ip)) existing.ips.push(ip);
+        }
+      }
+      continue;
+    }
+    const siteId = info.location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    ndOnlyDevices.push({
+      mac,
+      macs: [mac],
+      ips: [...info.ips],
+      vendor: info.vendor || lookupVendor(mac),
+      location: info.location,
+      siteId,
+      seenByHostname: info.seenByHostname,
+      seenByInterface: info.seenByPort,
+      seenByIp: undefined,
+      seenByMac: undefined,
+    });
+  }
+
+  if (ndOnlyDevices.length > 0) {
+    cache.set("arpDevices", [...existingArpDevices, ...ndOnlyDevices], TTL.PORTS);
+  }
+
+  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyDevices.length} ND-only unmanaged devices`);
+}
+```
+
+- [ ] **Step 4: Wire `pollNdNeighbours` into `warmCache`**
+
+Find the `warmCache` function (around line 723):
+```typescript
+export async function warmCache() {
+  console.log("[poller] Warming cache...");
+  await loadOuiDatabases();
+  await initWebSession();
+  await pollDevicesAndLocations();
+  await pollAlerts();
+  await pollPortsAndIps();
+  await pollRoutes();
+  console.log("[poller] Cache warm complete");
+}
+```
+Replace with:
+```typescript
+export async function warmCache() {
+  console.log("[poller] Warming cache...");
+  await loadOuiDatabases();
+  await initWebSession();
+  await pollDevicesAndLocations();
+  await pollAlerts();
+  await pollPortsAndIps();
+  await pollRoutes();
+  await pollNdNeighbours();
+  console.log("[poller] Cache warm complete");
+}
+```
+
+- [ ] **Step 5: Wire `pollNdNeighbours` into `startPoller`**
+
+Find the `startPoller` function (around line 742):
+```typescript
+export function startPoller() {
+  safeInterval(pollDevicesAndLocations, DEVICE_POLL_MS);
+  safeInterval(pollPortsAndIps, TTL.PORTS);
+  safeInterval(pollAlerts, TTL.ALERTS);
+  safeInterval(pollRoutes, TTL.PORTS);
+}
+```
+Replace with:
+```typescript
+export function startPoller() {
+  safeInterval(pollDevicesAndLocations, DEVICE_POLL_MS);
+  safeInterval(pollPortsAndIps, TTL.PORTS);
+  safeInterval(pollAlerts, TTL.ALERTS);
+  safeInterval(pollRoutes, TTL.PORTS);
+  safeInterval(pollNdNeighbours, TTL.PORTS);
+}
+```
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+cd /home/jkumar/Librenms-dash/backend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/jobs/poller.ts
+git commit -m "feat: add pollNdNeighbours — scrape IPv6 ND cache, enrich managed devices and discover ND-only unmanaged"
+```
+
+---
+
+### Task 3: Inject ND global IPv6 into topology and device-overview routes
+
+**Files:**
+- Modify: `backend/src/routes/topology.ts` — inject `ndGlobalIpv6` into `DeviceSummary.ips[]` and `allIps[]`
+- Modify: `backend/src/routes/devices.ts` — inject `ndGlobalIpv6` into device overview `deviceIps`
+
+**Interfaces:**
+- Consumes: cache key `"ndGlobalIpv6"` → `Map<string, string[]>` set by `pollNdNeighbours` in Task 2
+
+- [ ] **Step 1: Inject into `backend/src/routes/topology.ts`**
+
+Find the block starting with `// All addresses for search` (added in the previous IPv6 session, around line 63):
+```typescript
+    // All addresses for search — includes link-local, ULA, and loopback IPv6
+    const allIpsSet = new Set<string>(deviceIps);
+    for (const entry of ips) {
+      if (entry.ipv4_address) allIpsSet.add(entry.ipv4_address);
+      const v6 = entry.ipv6_compressed ?? entry.ipv6_address;
+      if (v6) allIpsSet.add(v6);
+    }
+    if (device.ip) allIpsSet.add(device.ip);
+```
+
+Replace with:
+```typescript
+    // All addresses for search — includes link-local, ULA, and loopback IPv6
+    const allIpsSet = new Set<string>(deviceIps);
+    for (const entry of ips) {
+      if (entry.ipv4_address) allIpsSet.add(entry.ipv4_address);
+      const v6 = entry.ipv6_compressed ?? entry.ipv6_address;
+      if (v6) allIpsSet.add(v6);
+    }
+    if (device.ip) allIpsSet.add(device.ip);
+
+    // ND-scraped global IPv6 for this device (not available via REST API)
+    const ndGlobalIpv6 = cache.get<Map<string, string[]>>("ndGlobalIpv6");
+    const deviceNdV6 = ndGlobalIpv6?.get(device.hostname) ?? [];
+    for (const v6 of deviceNdV6) {
+      if (!deviceIps.includes(v6)) deviceIps.push(v6);
+      allIpsSet.add(v6);
+    }
+```
+
+- [ ] **Step 2: Inject into `backend/src/routes/devices.ts`**
+
+Find the device overview's IP block (around line 73):
+```typescript
+  const deviceIps = findDeviceIps(ips, ports);
+  if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+  const arpLanIps = cache.get<Map<string, string>>("arpLanIps");
+  const arpLanIp = arpLanIps?.get(hostname);
+  if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+```
+
+Replace with:
+```typescript
+  const deviceIps = findDeviceIps(ips, ports);
+  if (device.ip && !deviceIps.includes(device.ip)) deviceIps.push(device.ip);
+  const arpLanIps = cache.get<Map<string, string>>("arpLanIps");
+  const arpLanIp = arpLanIps?.get(hostname);
+  if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+  const ndGlobalIpv6 = cache.get<Map<string, string[]>>("ndGlobalIpv6");
+  for (const v6 of ndGlobalIpv6?.get(hostname) ?? []) {
+    if (!deviceIps.includes(v6)) deviceIps.push(v6);
+  }
+```
+
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd /home/jkumar/Librenms-dash/backend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/routes/topology.ts backend/src/routes/devices.ts
+git commit -m "feat: inject ND-discovered global IPv6 into device IP lists and search"
+```
+
+---
+
+### Task 4: Build and verify
+
+- [ ] **Step 1: Docker build**
+
+```bash
+cd /home/jkumar/Librenms-dash && docker-compose up -d --build
+```
+
+Expected: build completes, container starts.
+
+- [ ] **Step 2: Watch logs for ND poll output**
+
+```bash
+docker-compose logs -f 2>&1 | grep -E "\[poller\].*ND|Cache warm"
+```
+
+Expected (after cache warm completes):
+```
+[poller] ND: N entries scanned, M managed devices enriched, K ND-only unmanaged devices
+[poller] Cache warm complete
+```
+
+If `LIBRENMS_USER`/`LIBRENMS_PASS` are not set, instead expect:
+```
+[web-client] Route polling disabled — LIBRENMS_USER/LIBRENMS_PASS not configured
+[poller] Cache warm complete
+```
+(ND polling silently skips — correct behaviour.)
+
+- [ ] **Step 3: Verify global IPv6 appears on managed devices**
+
+Open the dashboard. Click a device known to have IPv6 on its LAN (e.g. the Ubiquiti or Raspberry Pi visible in the ND probe output). In the device popover IP rows, a `2406:…` global unicast address should now appear alongside the IPv4 address.
+
+- [ ] **Step 4: Verify ND-only unmanaged devices appear**
+
+If any MACs were found in ND but not in ARP, they appear as new unmanaged device boxes in the site they were seen in, showing their global or ULA IPv6 as the IP label.
+
+- [ ] **Step 5: Verify search**
+
+Type a partial `2406:` or the full global IPv6 of a managed device into the topology search bar. The device should highlight.

--- a/docs/superpowers/specs/2026-06-27-ipv6-interface-addresses-design.md
+++ b/docs/superpowers/specs/2026-06-27-ipv6-interface-addresses-design.md
@@ -1,0 +1,58 @@
+# IPv6 Interface Addresses in Topology
+
+**Date:** 2026-06-27
+**Scope:** Surface IPv6 addresses already present in LibreNMS per-device IP data into the topology and device detail views.
+
+## Background
+
+Probing confirmed that this LibreNMS instance has no working IPv6 ND (Neighbor Discovery) REST API — global ND endpoints return 404, per-device endpoints return 500. The only available source of IPv6 data is the existing `/devices/{hostname}/ip` endpoint already polled in `pollPortsAndIps`.
+
+`LnmsDeviceIp` already has optional `ipv6_address` / `ipv6_compressed` / `ipv6_prefixlen` / `ipv6_origin` fields. `findDeviceIps()` in `overlays.ts` already reads them and applies correct filters (drops link-local `fe80::`, loopback `::1`, ULA `fc/fd`). So `DeviceSummary.ips[]` flows IPv6 to the frontend whenever LibreNMS returns it.
+
+Two backend gaps remain unfixed, plus the frontend interface table needs truncation for IPv6 widths.
+
+## Changes
+
+### 1. `backend/src/routes/devices.ts` — `ipsByPort` map
+
+**Where:** lines 52–59, inside the `/overview` handler.
+
+**Problem:** The map that builds per-interface IP lists (`port_id → string[]`) only reads `ip.ipv4_address`. IPv6 addresses on a port never appear in `DeviceInterface.ips[]`.
+
+**Fix:** Also read `ip.ipv6_compressed ?? ip.ipv6_address` and add it to the same map entry. No filter needed here — the interface detail view benefits from showing all addresses including link-local.
+
+### 2. `backend/src/jobs/poller.ts` — `currIps` change-detection set
+
+**Where:** lines 189–191, inside `pollPortsAndIps`.
+
+**Problem:** The set that drives asset change events only tracks `hostname ipv4_address`. IPv6 addresses appearing or disappearing go undetected.
+
+**Fix:** For each `LnmsDeviceIp`, also add `hostname ipv6_compressed` (or `ipv6_address`) to `currIps`. Skip link-local (`fe80:`) and loopback (`::1`) to avoid noisy events.
+
+### 3. `frontend/src/components/DevicePopover.tsx` — interface IPs column
+
+**Where:** lines 287–295, the IPs `<td>` in the interfaces table.
+
+**Problem:** Each IP is rendered in a plain `<div>` with `<Copyable>` but no `block` prop, so IPv6 addresses (up to 39 chars) widen the column.
+
+**Fix:**
+- Add `overflow-hidden` to the `<td>`.
+- Pass `block` prop to `<Copyable>` — this adds `block truncate` CSS, clamping the text to the cell width. The existing `title={text}` on `Copyable` already shows the full address on hover. Copy-on-click already works via `Copyable`.
+
+The main device IP rows (lines 133–140) already pass `block` and sit inside a `table-fixed` table, so they are already correct.
+
+## What is NOT changing
+
+- `LnmsDeviceIp` type — already has IPv6 fields.
+- `findDeviceIps()` — already handles IPv6 correctly.
+- `DeviceSummary.ips[]` / `Device.ips[]` — already include IPv6 when present.
+- `DeviceSummary.macs[]` — already sourced from port `ifPhysAddress` (no change).
+- Frontend search, device node labels, topology links — already consume `ips[]`.
+- No new API calls, no new cache keys, no shared type changes.
+
+## Verification
+
+1. `docker-compose up -d --build` succeeds.
+2. Open device popover for a device with known IPv6 addresses — IPv6 appears in the IP rows and in the per-interface IPs column.
+3. IPv6 in the interface column is truncated with `…`; hovering shows the full address; clicking copies it.
+4. Asset event log shows IPv6 add/remove events when an interface's IPv6 changes.

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -285,13 +285,20 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                         <Copyable text={iface.mac} block>{iface.mac}</Copyable>
                       </td>
                       <td className="py-0.5 px-2 font-mono text-gray-300 overflow-hidden">
-                        {iface.ips.length > 0
-                          ? iface.ips.map((ip) => (
-                              <div key={ip} className="leading-tight">
-                                <Copyable text={ip} block>{ip}</Copyable>
-                              </div>
-                            ))
-                          : "—"}
+                        {(() => {
+                          const displayIps = iface.ips.filter((ip) => {
+                            if (!ip.includes(":")) return true; // IPv4 always shown
+                            const l = ip.toLowerCase();
+                            return !l.startsWith("fe80:") && !l.startsWith("fc") && !l.startsWith("fd") && l !== "::1";
+                          });
+                          return displayIps.length > 0
+                            ? displayIps.map((ip) => (
+                                <div key={ip} className="leading-tight">
+                                  <Copyable text={ip} block>{ip}</Copyable>
+                                </div>
+                              ))
+                            : "—";
+                        })()}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -284,11 +284,11 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                       <td className="py-0.5 px-2 font-mono text-gray-400">
                         <Copyable text={iface.mac} block>{iface.mac}</Copyable>
                       </td>
-                      <td className="py-0.5 px-2 font-mono text-gray-300">
+                      <td className="py-0.5 px-2 font-mono text-gray-300 overflow-hidden">
                         {iface.ips.length > 0
                           ? iface.ips.map((ip) => (
                               <div key={ip} className="leading-tight">
-                                <Copyable text={ip}>{ip}</Copyable>
+                                <Copyable text={ip} block>{ip}</Copyable>
                               </div>
                             ))
                           : "—"}

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -253,6 +253,7 @@ export function TopologyMap({ data, sse }: Props) {
           dev.ip?.includes(qLower) ||
           dev.lanIp?.includes(qLower) ||
           dev.ips?.some((ip) => ip.includes(qLower)) ||
+          dev.allIps?.some((ip) => ip.includes(qLower)) ||
           dev.overlayPorts?.some((p) => p.ip?.includes(qLower)) ||
           (looksLikeMac && dev.macs?.some((m) => normalizeMacSearch(m).includes(qMac)))
         ) {

--- a/scripts/probe-ipv6-nd.sh
+++ b/scripts/probe-ipv6-nd.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Probe LibreNMS API for IPv6 ND / neighbour-discovery endpoints.
+# Reads LIBRENMS_URL and LIBRENMS_TOKEN from .env in the repo root.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: .env not found at $ENV_FILE" >&2
+  exit 1
+fi
+
+# Source only the two vars we need (ignore errors for unset vars)
+LIBRENMS_URL=""
+LIBRENMS_TOKEN=""
+while IFS='=' read -r key val; do
+  [[ "$key" =~ ^# ]] && continue
+  [[ -z "$key" ]] && continue
+  val="${val%%#*}"        # strip inline comments
+  val="${val%"${val##*[![:space:]]}"}"  # strip trailing whitespace
+  case "$key" in
+    LIBRENMS_URL)   LIBRENMS_URL="$val" ;;
+    LIBRENMS_TOKEN) LIBRENMS_TOKEN="$val" ;;
+  esac
+done < "$ENV_FILE"
+
+if [[ -z "$LIBRENMS_URL" || -z "$LIBRENMS_TOKEN" ]]; then
+  echo "ERROR: LIBRENMS_URL or LIBRENMS_TOKEN missing from .env" >&2
+  exit 1
+fi
+
+BASE="${LIBRENMS_URL%/}/api/v0"
+HDR="X-Auth-Token: $LIBRENMS_TOKEN"
+
+probe() {
+  local label="$1"
+  local path="$2"
+  echo ""
+  echo "=== $label ==="
+  echo "    GET $path"
+  local http_code body
+  body=$(curl -sk -o /tmp/probe_body.json -w "%{http_code}" \
+    -H "$HDR" "${BASE}${path}") || { echo "    [curl error]"; return; }
+  http_code="$body"
+  echo "    HTTP $http_code"
+  if [[ "$http_code" == "200" ]]; then
+    # Print top-level keys and first element of any array (truncated)
+    python3 - /tmp/probe_body.json <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    try:
+        data = json.load(f)
+    except Exception as e:
+        print(f"    [invalid JSON: {e}]")
+        sys.exit(0)
+
+if isinstance(data, dict):
+    for k, v in data.items():
+        if isinstance(v, list):
+            print(f"    .{k}: list[{len(v)}]", end="")
+            if v:
+                sample = v[0]
+                keys = list(sample.keys()) if isinstance(sample, dict) else repr(sample)[:80]
+                print(f"  sample keys: {keys}")
+            else:
+                print("  (empty)")
+        else:
+            print(f"    .{k}: {repr(v)[:80]}")
+elif isinstance(data, list):
+    print(f"    list[{len(data)}]")
+    if data and isinstance(data[0], dict):
+        print(f"    sample keys: {list(data[0].keys())}")
+PYEOF
+  else
+    head -c 200 /tmp/probe_body.json && echo ""
+  fi
+}
+
+# ---- Pick one device hostname for per-device probes ----
+echo "Fetching device list to pick a probe target..."
+curl -sk -H "$HDR" "${BASE}/devices?limit=1" -o /tmp/probe_devices.json
+HOSTNAME=$(python3 -c "
+import json, ipaddress
+with open('/tmp/probe_devices.json') as f:
+    d = json.load(f)
+devs = d.get('devices', [])
+# Prefer active devices on physical (non-overlay) IPs
+# Skip Tailscale (100.64/10), ZeroTier (10.147.*), and other common overlay ranges
+OVERLAY_NETS = [
+    ipaddress.ip_network('100.64.0.0/10'),   # Tailscale CGNAT
+    ipaddress.ip_network('10.147.0.0/16'),    # ZeroTier default
+    ipaddress.ip_network('172.16.0.0/12'),    # Docker bridge
+]
+def is_overlay(ip):
+    try:
+        a = ipaddress.ip_address(ip)
+        return any(a in net for net in OVERLAY_NETS)
+    except Exception:
+        return False
+active = [x for x in devs if x.get('status') == 1]
+physical = [x for x in active if not is_overlay(x.get('ip',''))]
+pick = physical[0] if physical else (active[0] if active else (devs[0] if devs else None))
+if pick:
+    print(pick['hostname'])
+" 2>/dev/null || true)
+
+if [[ -z "$HOSTNAME" ]]; then
+  echo "WARNING: could not pick a device; skipping per-device probes"
+fi
+
+echo ""
+echo "Target device: ${HOSTNAME:-none}"
+echo "============================================================"
+
+# ---- Global endpoints ----
+probe "ARP all (baseline — known working)"     "/resources/ip/arp/all"
+probe "IPv6 v6 all"                            "/resources/ip/v6/all"
+probe "IPv6 v6-neighbours all"                 "/resources/ip/v6-neighbours"
+probe "IPv6 addresses (all)"                   "/resources/ip/addresses"
+
+# ---- Per-device endpoints ----
+if [[ -n "$HOSTNAME" ]]; then
+  probe "Per-device: ip (baseline)"             "/devices/${HOSTNAME}/ip"
+  probe "Per-device: ipv6"                      "/devices/${HOSTNAME}/ipv6"
+  probe "Per-device: ipv6neighbours"            "/devices/${HOSTNAME}/ipv6neighbours"
+  probe "Per-device: ipv6-neighbours"           "/devices/${HOSTNAME}/ipv6-neighbours"
+  probe "Per-device: neighbours (LLDP/CDP)"     "/devices/${HOSTNAME}/neighbours"
+
+  echo ""
+  echo "=== Raw body: ipv6neighbours for $HOSTNAME ==="
+  curl -sk -H "$HDR" "${BASE}/devices/${HOSTNAME}/ipv6neighbours" | head -c 500
+  echo ""
+fi
+
+echo ""
+echo "============================================================"
+echo "Done. Check HTTP 200 entries above for usable ND endpoints."
+rm -f /tmp/probe_body.json /tmp/probe_devices.json

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -70,6 +70,7 @@ export interface DeviceSummary {
   ip: string;
   lanIp: string;
   ips: string[];
+  allIps: string[];
   macs: string[];
   os: string;
   icon: string;


### PR DESCRIPTION
## Summary

- **IPv6 interface addresses**: Surface IPv6 addresses from the LibreNMS REST API into per-interface IP lists and device summaries. Global unicast IPv6 shown in UI; link-local/ULA/loopback kept in search index only.
- **IPv6 ND web scraping**: Scrape `/device/{id}/ports/nd` HTML for each managed device to extract Neighbor Discovery cache entries. Uses those to enrich managed devices with global-unicast IPv6 not available via REST API, and discovers ND-only unmanaged devices.
- **Overlay IP fix**: Exclude overlay management IPs (Tailscale 100.x, ZeroTier 172.29.x) from the device IP display list; they remain searchable and visible in the dedicated Overlay section.

## Key changes

- `backend/src/librenms/types.ts` — `LnmsNdEntry` interface
- `backend/src/librenms/web-client.ts` — `parseNdTable` + `fetchNdNeighbours` HTML scraper
- `backend/src/jobs/poller.ts` — `pollNdNeighbours()` wired into `warmCache` + `safeInterval`; writes `ndGlobalIpv6` cache (`Map<hostname, string[]>`); merges ND-only MACs into `arpDevices`
- `backend/src/routes/topology.ts` — injects ND IPv6 into `DeviceSummary.ips`/`allIps`; overlay IP guard on `device.ip` push
- `backend/src/routes/devices.ts` — injects ND IPv6 into device overview; overlay IP guard on `device.ip` push; IPv6 in per-interface `ipsByPort`
- `frontend/src/components/DevicePopover.tsx` — global-only IPv6 display in interface table, truncated with copy-on-click
- `shared/types.ts` — `allIps: string[]` on `DeviceSummary` for full-scope search

## Test plan

- [ ] Cache warm log shows `ND: N entries scanned, M managed devices enriched, K ND-only unmanaged devices`
- [ ] Topology device nodes show global unicast IPv6 alongside LAN IPs; no overlay IPs in the list
- [ ] Device popover interface table shows IPv6 (global only) truncated with copy-on-click; overlay IPs visible there
- [ ] Search finds devices by link-local, ULA, and global IPv6 addresses
- [ ] Overlay IPs (Tailscale 100.x, ZeroTier 172.x) no longer appear in the main device IP list

🤖 Generated with [Claude Code](https://claude.com/claude-code)