### PR TITLE
feat: SSE inline topology payload + gzip compression

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { streamSSE } from "hono/streaming";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
+import { compress } from "hono/compress";
 import { PORT } from "./config.js";
 import { warmCache, startPoller } from "./jobs/poller.js";
 import topologyRoutes from "./routes/topology.js";
@@ -16,6 +17,7 @@ import { requireAuth } from "./middleware/auth.js";
 
 const app = new Hono();
 
+app.use("*", compress());
 app.use("*", logger());
 app.use("*", cors({
   origin: process.env.NODE_ENV === "production"

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -228,7 +228,8 @@ function flushTopologyChanged() {
   if (!topologyChangedInCycle) return;
   topologyChangedInCycle = false;
   buildAndCacheTopology();
-  const payload = cache.get<TopologyResponse>("topology")!;
+  const payload = cache.get<TopologyResponse>("topology");
+  if (!payload) return;
   for (const fn of topologyListeners) fn(payload);
 }
 
@@ -1008,7 +1009,6 @@ export async function warmCache() {
   await pollPortsAndIps();
   await pollRoutes();
   await pollNdNeighbours();
-  buildAndCacheTopology();
   console.log("[poller] Cache warm complete");
 }
 

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -1,12 +1,12 @@
 import { cache, TTL } from "../cache/store.js";
 import { librenmsGet, delay } from "../librenms/client.js";
-import { buildOverlayLinks, engine, isExcludedIface, isDockerIp, findLanIp } from "../librenms/overlays.js";
+import { buildOverlayLinks, engine, isExcludedIface, isDockerIp, findLanIp, getOverlayPortSummaries, findDeviceIps } from "../librenms/overlays.js";
 import { loadOuiDatabases, lookupVendor, normalizeMac } from "../librenms/oui.js";
 import { makeCidrMatcher } from "../librenms/cidr.js";
 import { ARP_EXCLUDED_SUBNETS, OVERLAY_SUBNET_LIST } from "../config.js";
 import { initWebSession, isWebClientEnabled, fetchRoutes, fetchNdNeighbours, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
 import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry, LnmsNdEntry } from "../librenms/types.js";
-import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent } from "@librenms-dash/shared";
+import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent, TopologyResponse, Site, DeviceSummary, NeighborLink } from "@librenms-dash/shared";
 
 const STAGGER_MS = 200;
 
@@ -42,13 +42,181 @@ const prevDeviceStatus = new Map<string, number>();
 let eventSeq = 0;
 const MAX_EVENTS = 200;
 
+const commitSha: string | undefined = process.env.COMMIT_SHA || undefined;
+
+function deriveDisplayName(device: LnmsDevice): string {
+  if (device.display) return device.display;
+  const name = device.sysName || device.hostname;
+  return name.replace(/\.local\.lan$/, "").replace(/\.local\.zt$/, "").replace(/\.[a-z]+\.[a-z]+$/, "");
+}
+
+export function buildAndCacheTopology(): void {
+  const devices = cache.get<LnmsDevice[]>("devices") ?? [];
+  const locations = cache.get<LnmsLocation[]>("locations") ?? [];
+  const overlays = cache.get<import("@librenms-dash/shared").SubnetGroup[]>("overlays") ?? [];
+  const alerts = cache.get<LnmsAlert[]>("alerts") ?? [];
+  const lnmsLinks = cache.get<LnmsLink[]>("links") ?? [];
+
+  const locationMap = new Map<string, LnmsLocation>();
+  for (const loc of locations) locationMap.set(loc.location, loc);
+
+  const arpLanIps = cache.get<Map<string, string>>("arpLanIps") ?? new Map<string, string>();
+  const ndGlobalIpv6 = cache.get<Map<string, string[]>>("ndGlobalIpv6");
+
+  const siteMap = new Map<string, Site>();
+
+  for (const device of devices) {
+    const locName = device.location || "Unknown";
+    if (!siteMap.has(locName)) {
+      const loc = locationMap.get(locName);
+      siteMap.set(locName, {
+        id: locName.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+        location: locName,
+        lat: loc?.lat ?? null,
+        lng: loc?.lng ?? null,
+        devices: [],
+      });
+    }
+
+    const ports = cache.get<LnmsPort[]>(`ports:${device.hostname}`) ?? [];
+    const ips = cache.get<LnmsDeviceIp[]>(`ips:${device.hostname}`) ?? [];
+
+    let totalIn = 0;
+    let totalOut = 0;
+    const macSet = new Set<string>();
+    for (const p of ports) {
+      totalIn += p.ifInOctets_rate ?? 0;
+      totalOut += p.ifOutOctets_rate ?? 0;
+      const mac = normalizeMac(p.ifPhysAddress ?? "");
+      if (mac && mac.length === 12 && mac !== "000000000000") macSet.add(mac);
+    }
+
+    let lanIp = findLanIp(device.ip, ips, ports);
+    const deviceIps = findDeviceIps(ips, ports);
+    if (device.ip && !deviceIps.includes(device.ip) && !engine.isOverlayIp(device.ip)) deviceIps.push(device.ip);
+    const arpLanIp = arpLanIps.get(device.hostname);
+
+    const allIpsSet = new Set<string>(deviceIps);
+    for (const entry of ips) {
+      if (entry.ipv4_address) allIpsSet.add(entry.ipv4_address);
+      const v6 = entry.ipv6_compressed ?? entry.ipv6_address;
+      if (v6) allIpsSet.add(v6);
+    }
+    if (device.ip) allIpsSet.add(device.ip);
+
+    const deviceNdV6 = ndGlobalIpv6?.get(device.hostname) ?? [];
+    for (const v6 of deviceNdV6) {
+      if (!deviceIps.includes(v6)) deviceIps.push(v6);
+      allIpsSet.add(v6);
+    }
+
+    if (arpLanIp && engine.isOverlayIp(lanIp)) lanIp = arpLanIp;
+    if (arpLanIp && !deviceIps.includes(arpLanIp)) deviceIps.unshift(arpLanIp);
+
+    const summary: DeviceSummary = {
+      device_id: device.device_id,
+      hostname: device.hostname,
+      displayName: deriveDisplayName(device),
+      ip: device.ip,
+      lanIp,
+      ips: deviceIps,
+      allIps: [...allIpsSet],
+      macs: [...macSet],
+      os: device.os,
+      icon: device.icon,
+      status: device.status,
+      uptime: device.uptime,
+      location: device.location,
+      hardware: device.hardware,
+      sysName: device.sysName,
+      totalInRate: totalIn,
+      totalOutRate: totalOut,
+      portCount: ports.length,
+      overlayPorts: getOverlayPortSummaries(ports, ips),
+      routes: cache.get<DeviceRoute[]>(`routes:${device.hostname}`) ?? undefined,
+    };
+
+    siteMap.get(locName)!.devices.push(summary);
+  }
+
+  const deviceIdMap = new Map<number, LnmsDevice>();
+  for (const d of devices) deviceIdMap.set(d.device_id, d);
+  const deviceHostnameMap = new Map<string, LnmsDevice>();
+  for (const d of devices) deviceHostnameMap.set(d.hostname, d);
+
+  const portNameMap = new Map<number, string>();
+  for (const device of devices) {
+    const ports = cache.get<LnmsPort[]>(`ports:${device.hostname}`) ?? [];
+    for (const p of ports) portNameMap.set(p.port_id, p.ifName || p.ifDescr || `port-${p.port_id}`);
+  }
+
+  const neighborSet = new Set<string>();
+  const neighbors: NeighborLink[] = [];
+  for (const link of lnmsLinks) {
+    const localDev = deviceIdMap.get(link.local_device_id);
+    const remoteDev = deviceIdMap.get(link.remote_device_id);
+    if (!localDev || !remoteDev) continue;
+
+    const localPortName = portNameMap.get(link.local_port_id) ?? "";
+    const remotePortName = portNameMap.get(link.remote_port_id) ?? link.remote_port ?? "";
+    if (localPortName && isExcludedIface(localPortName)) continue;
+    if (remotePortName && isExcludedIface(remotePortName)) continue;
+
+    const key = [link.local_device_id, link.remote_device_id].sort().join("-") +
+      ":" + [link.local_port_id, link.remote_port_id].sort().join("-");
+    if (neighborSet.has(key)) continue;
+    neighborSet.add(key);
+
+    neighbors.push({
+      id: link.id,
+      localDeviceId: link.local_device_id,
+      localHostname: localDev.hostname,
+      localPort: localPortName || `port-${link.local_port_id}`,
+      remoteDeviceId: link.remote_device_id,
+      remoteHostname: remoteDev.hostname,
+      remotePort: remotePortName || `port-${link.remote_port_id}`,
+      protocol: link.protocol,
+    });
+  }
+
+  const arpLinks = (cache.get<ArpLink[]>("arpLinks") ?? []).filter((link) => {
+    const fromDevice = deviceHostnameMap.get(link.fromHostname);
+    const toDevice = deviceHostnameMap.get(link.toHostname);
+    if (!fromDevice || !toDevice) return false;
+    return (fromDevice.location || "Unknown") === (toDevice.location || "Unknown");
+  });
+
+  const arpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+
+  const payload: TopologyResponse = {
+    sites: [...siteMap.values()],
+    overlays,
+    neighbors,
+    arpLinks,
+    arpDevices,
+    alerts: alerts.map((a) => ({
+      id: a.id,
+      device_id: a.device_id,
+      hostname: a.hostname,
+      rule: typeof a.rule === "string" ? a.rule : a.rule?.name ?? "",
+      severity: a.severity,
+      state: a.state,
+      timestamp: a.timestamp,
+    })),
+    lastUpdated: new Date().toISOString(),
+    commitSha,
+  };
+
+  cache.set("topology", payload, TTL.PORTS);
+}
+
 type EventListener = (events: AssetEvent[]) => void;
 const sseListeners = new Set<EventListener>();
 
 export function subscribeEvents(fn: EventListener) { sseListeners.add(fn); }
 export function unsubscribeEvents(fn: EventListener) { sseListeners.delete(fn); }
 
-type TopologyListener = () => void;
+type TopologyListener = (payload: TopologyResponse) => void;
 const topologyListeners = new Set<TopologyListener>();
 
 export function subscribeTopologyChanged(fn: TopologyListener) { topologyListeners.add(fn); }
@@ -59,7 +227,9 @@ let topologyChangedInCycle = false;
 function flushTopologyChanged() {
   if (!topologyChangedInCycle) return;
   topologyChangedInCycle = false;
-  for (const fn of topologyListeners) fn();
+  buildAndCacheTopology();
+  const payload = cache.get<TopologyResponse>("topology")!;
+  for (const fn of topologyListeners) fn(payload);
 }
 
 function pushEvents(events: AssetEvent[]) {
@@ -204,10 +374,10 @@ export async function pollPortsAndIps() {
   flushTopologyChanged();
 
   // Build ARP-based connections (non-blocking, runs in background)
-  pollArpLinks(devices, allIps).catch(e => console.warn("[poller] ARP poll failed:", e));
+  pollArpLinks(devices, allIps, allPorts).catch(e => console.warn("[poller] ARP poll failed:", e));
 }
 
-async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDeviceIp[]>) {
+async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDeviceIp[]>, allPorts: Map<string, LnmsPort[]>) {
   console.log("[poller] Building ARP link map...");
 
   const deviceIdToHostname = new Map<number, string>();
@@ -243,7 +413,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   const portIdToIfName = new Map<number, string>();
   const portIdToMac = new Map<number, string>();
   for (const d of allDevicesForExclusion) {
-    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    const ports = allPorts.get(d.hostname) ?? cache.get<LnmsPort[]>(`ports:${d.hostname}`);
     if (!ports) continue;
     for (const p of ports) {
       const name = p.ifName || p.ifDescr;
@@ -258,7 +428,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   // whose IP endpoint 404s but whose interface MACs appear in other ARP tables).
   const macToHostname = new Map<string, string>();
   for (const d of devices) {
-    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    const ports = allPorts.get(d.hostname) ?? cache.get<LnmsPort[]>(`ports:${d.hostname}`);
     if (!ports) continue;
     for (const p of ports) {
       const mac = normalizeMac(p.ifPhysAddress ?? "");
@@ -300,7 +470,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   const hostnameToLocalIp = new Map<string, string>();
   for (const d of devices) {
     const ips = allIps.get(d.hostname) ?? [];
-    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`) ?? [];
+    const ports = allPorts.get(d.hostname) ?? cache.get<LnmsPort[]>(`ports:${d.hostname}`) ?? [];
     hostnameToLocalIp.set(d.hostname, findLanIp(d.ip, ips, ports));
   }
 
@@ -439,7 +609,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
       locMacs = new Set();
       managedMacsByLocation.set(loc, locMacs);
     }
-    const cached = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
+    const cached = allPorts.get(d.hostname) ?? cache.get<LnmsPort[]>(`ports:${d.hostname}`);
     if (cached) {
       for (const p of cached) {
         const mac = normalizeMac(p.ifPhysAddress ?? "");
@@ -771,17 +941,16 @@ export async function pollNdNeighbours() {
 
   // Merge ND-only unmanaged devices into existing arpDevices
   const existingArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
-  const existingMacSet = new Set(existingArpDevices.map((d) => normalizeMac(d.mac)));
+  const macToArpDevice = new Map(existingArpDevices.map((d) => [normalizeMac(d.mac), d]));
 
   const ndOnlyDevices: ArpDiscoveredDevice[] = [];
   for (const [mac, info] of ndUnmanaged) {
-    if (existingMacSet.has(mac)) {
+    const existing = macToArpDevice.get(mac);
+    if (existing) {
       // Enrich existing ARP entry with IPv6 addresses
-      const existing = existingArpDevices.find((d) => normalizeMac(d.mac) === mac);
-      if (existing) {
-        for (const ip of info.ips) {
-          if (!existing.ips.includes(ip)) existing.ips.push(ip);
-        }
+      const ipSet = new Set(existing.ips);
+      for (const ip of info.ips) {
+        if (!ipSet.has(ip)) { existing.ips.push(ip); ipSet.add(ip); }
       }
       continue;
     }
@@ -805,6 +974,7 @@ export async function pollNdNeighbours() {
   }
 
   console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyDevices.length} ND-only unmanaged devices`);
+  buildAndCacheTopology();
 }
 
 let prevAlertIds = new Set<number>();
@@ -838,6 +1008,7 @@ export async function warmCache() {
   await pollPortsAndIps();
   await pollRoutes();
   await pollNdNeighbours();
+  buildAndCacheTopology();
   console.log("[poller] Cache warm complete");
 }
 

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { cache } from "../cache/store.js";
 import { subscribeEvents, unsubscribeEvents, subscribeTopologyChanged, unsubscribeTopologyChanged } from "../jobs/poller.js";
-import type { AssetEvent } from "@librenms-dash/shared";
+import type { AssetEvent, TopologyResponse } from "@librenms-dash/shared";
 
 const app = new Hono();
 
@@ -19,8 +19,8 @@ app.get("/stream", (c) => {
 
     subscribeEvents(onEvents);
 
-    const onTopologyChanged = () => {
-      stream.writeSSE({ data: JSON.stringify({ ts: new Date().toISOString() }), event: "topology-changed" }).catch(() => {});
+    const onTopologyChanged = (payload: TopologyResponse) => {
+      stream.writeSSE({ data: JSON.stringify(payload), event: "topology-changed" }).catch(() => {});
     };
 
     subscribeTopologyChanged(onTopologyChanged);

--- a/docs/superpowers/specs/2026-06-29-sse-inline-payload-and-compression-design.md
+++ b/docs/superpowers/specs/2026-06-29-sse-inline-payload-and-compression-design.md
@@ -1,0 +1,125 @@
+# SSE Inline Topology Payload + HTTP Compression
+
+**Date:** 2026-06-29  
+**Status:** Approved
+
+## Problem
+
+Every SSE-triggered topology refresh costs two round trips: the SSE event (tiny) plus an HTTP GET `/api/topology` (200–600 KB). HTTP responses are also uncompressed — the topology JSON, device detail endpoints, and port data all go over the wire verbatim.
+
+## Goals
+
+1. Eliminate the HTTP refetch on topology change — send the full payload inline in the SSE event.
+2. Compress all HTTP API responses via gzip.
+
+## Non-Goals
+
+- SSE stream-level compression (complex, marginal benefit given SSE events are already flushed per-event).
+- Delta/partial topology payloads (deferred — see assessment item 5/7).
+
+---
+
+## Design
+
+### 1. Inline SSE Topology Payload
+
+**Backend — `jobs/poller.ts`:**
+
+`TopologyListener` type changes from `() => void` to `(payload: TopologyResponse) => void`.
+
+`flushTopologyChanged()` reads the pre-built topology from cache and passes it to each listener:
+
+```ts
+function flushTopologyChanged() {
+  if (!topologyChangedInCycle) return;
+  topologyChangedInCycle = false;
+  buildAndCacheTopology();
+  const payload = cache.get<TopologyResponse>("topology")!;
+  for (const fn of topologyListeners) fn(payload);
+}
+```
+
+**Backend — `routes/events.ts`:**
+
+`onTopologyChanged` receives the full payload and sends it as the `topology-changed` event body:
+
+```ts
+const onTopologyChanged = (payload: TopologyResponse) => {
+  stream.writeSSE({ data: JSON.stringify(payload), event: "topology-changed" }).catch(() => {});
+};
+```
+
+**Frontend — `hooks/useSSE.ts`:**
+
+Replace `queryClient.invalidateQueries(...)` with `queryClient.setQueryData(...)`:
+
+```ts
+es.addEventListener("topology-changed", (e) => {
+  try {
+    const payload = JSON.parse(e.data) as TopologyResponse;
+    queryClient.setQueryData(["topology"], payload);
+  } catch { /* ignore */ }
+});
+```
+
+On reconnect, trigger a full HTTP refetch to sync any topology changes missed while the SSE was disconnected:
+
+```ts
+const isFirstOpen = useRef(true);
+es.onopen = () => {
+  setConnected(true);
+  if (!isFirstOpen.current) {
+    queryClient.invalidateQueries({ queryKey: ["topology"] });
+  }
+  isFirstOpen.current = false;
+};
+```
+
+The `/api/topology` HTTP endpoint remains unchanged — used for initial page load and reconnect sync.
+
+### 2. HTTP Response Compression
+
+Hono ships a `compress` middleware (`hono/compress`) that negotiates gzip/deflate/brotli via `Accept-Encoding`. It is added globally in `backend/src/index.ts`, before routes:
+
+```ts
+import { compress } from "hono/compress";
+app.use("*", compress());
+```
+
+The middleware only compresses buffered (non-streaming) responses. SSE routes respond with `Content-Type: text/event-stream` via Hono's `streamSSE`, which produces a streaming response — the compress middleware passes these through untouched.
+
+No per-route exclusions are needed.
+
+---
+
+## Data Flow (After)
+
+```
+Poll cycle ends
+  → buildAndCacheTopology() puts TopologyResponse in cache
+  → flushTopologyChanged() reads cache, calls topologyListeners(payload)
+  → routes/events.ts writes: event: topology-changed\ndata: <full JSON>\n\n
+  → Browser EventSource fires "topology-changed"
+  → useSSE: queryClient.setQueryData(["topology"], payload)
+  → React re-renders with new data
+  → Zero HTTP requests
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/index.ts` | Add `compress()` middleware |
+| `backend/src/jobs/poller.ts` | `TopologyListener` type, `flushTopologyChanged` passes payload |
+| `backend/src/routes/events.ts` | `onTopologyChanged(payload)` sends full JSON |
+| `frontend/src/hooks/useSSE.ts` | `setQueryData` instead of `invalidateQueries`; reconnect refetch |
+
+---
+
+## Trade-offs
+
+- **SSE event size increases**: topology JSON (~200–600 KB uncompressed) is sent in the SSE frame instead of a separate HTTP response. The HTTP response was also ~200–600 KB, so wire cost is unchanged — but we save one HTTP round trip per topology change.
+- **SSE stream is not compressed**: individual SSE frames can't be gzip-compressed without custom stream flushing. This is an acceptable trade-off since the primary benefit (eliminating the round trip) doesn't depend on compression.
+- **HTTP responses are compressed**: the initial `/api/topology` load, device detail, port data, and graph proxy responses all benefit from gzip — typically 5–10× reduction on JSON payloads.

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -51,7 +51,7 @@ export function useSSE() {
       isFirstOpen.current = false;
     };
     es.onerror = () => setConnected(false);
-    return () => { es.close(); setConnected(false); };
+    return () => { es.close(); setConnected(false); isFirstOpen.current = true; };
   }, [queryClient]);
 
   return { allEvents, connected };

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import type { AssetEvent } from "@librenms-dash/shared";
+import type { AssetEvent, TopologyResponse } from "@librenms-dash/shared";
 
 export function useSSE() {
   const queryClient = useQueryClient();
   const [allEvents, setAllEvents] = useState<AssetEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const addEventsRef = useRef<(events: AssetEvent[]) => void>();
+  const isFirstOpen = useRef(true);
 
   const addEvents = useCallback((events: AssetEvent[]) => {
     setAllEvents(prev => {
@@ -34,11 +35,21 @@ export function useSSE() {
       } catch { /* ignore */ }
     });
 
-    es.addEventListener("topology-changed", () => {
-      queryClient.invalidateQueries({ queryKey: ["topology"] });
+    es.addEventListener("topology-changed", (e) => {
+      try {
+        const payload = JSON.parse(e.data) as TopologyResponse;
+        queryClient.setQueryData(["topology"], payload);
+      } catch { /* ignore malformed events */ }
     });
 
-    es.onopen = () => setConnected(true);
+    es.onopen = () => {
+      setConnected(true);
+      if (!isFirstOpen.current) {
+        // SSE reconnected — resync in case events were missed while disconnected
+        queryClient.invalidateQueries({ queryKey: ["topology"] });
+      }
+      isFirstOpen.current = false;
+    };
     es.onerror = () => setConnected(false);
     return () => { es.close(); setConnected(false); };
   }, [queryClient]);


### PR DESCRIPTION
## Summary

- **Gzip compression on all HTTP API responses** via Hono's `compress()` middleware (`backend/src/index.ts`). SSE streaming responses are auto-skipped by the middleware — no per-route exclusions needed.
- **Full `TopologyResponse` embedded in SSE `topology-changed` event** — `TopologyListener` type updated from `() => void` to `(payload: TopologyResponse) => void`; `flushTopologyChanged()` reads the pre-built payload from cache and passes it to each listener; `routes/events.ts` writes it directly into the event frame.
- **Frontend uses `setQueryData` instead of `invalidateQueries`** on topology SSE events — eliminates the HTTP round-trip on every topology change. On reconnect (not initial open), `invalidateQueries` fires to resync any missed updates.
- **Quick-win optimizations** bundled in the SSE listener commit: pre-built topology cache (poller builds and stores `TopologyResponse` in `buildAndCacheTopology()`; route is now a simple cache read), lazy-compiled single CIDR matcher in `OverlayEngine.isOverlayIp()`, ND enrichment O(n) scan replaced with a `Map` lookup, and `pollArpLinks` receives `allPorts` to avoid redundant cache reads.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Topology change | SSE ping → HTTP GET `/api/topology` (200–600 KB) | SSE event with full payload → zero HTTP requests |
| HTTP API responses | Uncompressed JSON | gzip (typically 5–10× smaller) |
| `/api/topology` latency | O(n) rebuild per request | Cache read (~1 ms) |
| `isOverlayIp()` per ARP poll | Re-parses all CIDR subnets each call | Single compiled matcher, cached between polls |

## Test plan

- [ ] `docker-compose up -d --build` succeeds and container starts
- [ ] `curl -sI -H "Accept-Encoding: gzip" http://localhost:3001/api/health | grep -i content-encoding` → `content-encoding: gzip`
- [ ] SSE stream is NOT compressed: `curl -sI -H "Accept-Encoding: gzip" http://localhost:3001/api/events/stream | grep -i content-encoding` → no header
- [ ] Dashboard loads; DevTools → Network → after initial `/api/topology` fetch, **no further** `/api/topology` requests appear during live topology updates (watch SSE `events/stream` for `topology-changed` events instead)
- [ ] DevTools → Network → `/api/topology` initial response has `Content-Encoding: gzip`
- [ ] Disconnect network briefly, reconnect — dashboard re-fetches `/api/topology` once (reconnect sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)