### PR TITLE
Track lastSeen/firstSeen and dim stale discovered devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The dashboard is now available at **`http://<your-host-ip>:3001`**.
 - Overlay links for ZeroTier, WireGuard, Tailscale, GRE, IPSec, Tinc, PPTP, Tunnel, and TAP (auto-detected by interface name)
 - LLDP/CDP neighbor links
 - ARP-derived links, filtered to same-location devices
+- Discovered (unmanaged) devices seen via ARP/ND, with staleness tracking — a device that stops responding dims for 15 minutes before being removed after 24 hours, instead of vanishing after a single missed poll
 - Per-device IPv4 routing tables (next-hop, destination, interface)
 - Device hover popovers with traffic and health graphs
 - Real-time asset change notifications via SSE (device/port/IP added or removed)
@@ -194,6 +195,7 @@ When a device moves, its category underlay and connected links update. When a si
 
 - ARP links are filtered so devices in different LibreNMS locations do not form a link.
 - The backend caches LibreNMS data in memory with TTL-based refreshes. The device list (status, uptime, `last_polled`) is refreshed every 5 minutes; ports and alerts on their own intervals.
+- Discovered (ARP/ND) devices are tracked separately in an in-memory registry keyed by MAC, not a simple TTL cache — see [`docs/arp-deduplication-and-correlation.md`](docs/arp-deduplication-and-correlation.md#stage-5--staleness--retention) for how staleness and 24-hour retention work.
 - The production build bundles the frontend into `frontend/dist` and serves it from the backend process.
 
 ## Security

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outdir=dist --packages=external --banner:js=\"import{createRequire}from'module';const require=createRequire(import.meta.url);\"",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.0",
@@ -19,6 +20,7 @@
     "@types/node": "^22.15.0",
     "esbuild": "^0.28.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/backend/src/jobs/arpDeviceRegistry.test.ts
+++ b/backend/src/jobs/arpDeviceRegistry.test.ts
@@ -10,6 +10,7 @@ const baseDevice: ArpDeviceFields = {
   location: "HQ",
   siteId: "hq",
   seenByHostname: "switch1",
+  sourceDown: false,
 };
 
 describe("ArpDeviceRegistry", () => {

--- a/backend/src/jobs/arpDeviceRegistry.test.ts
+++ b/backend/src/jobs/arpDeviceRegistry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { ArpDeviceRegistry, STALE_THRESHOLD_MS, RETENTION_MS } from "./arpDeviceRegistry.js";
+import type { ArpDeviceFields } from "./arpDeviceRegistry.js";
+
+const baseDevice: ArpDeviceFields = {
+  mac: "aabbccddeeff",
+  macs: ["aabbccddeeff"],
+  ips: ["192.168.1.50"],
+  vendor: "Acme",
+  location: "HQ",
+  siteId: "hq",
+  seenByHostname: "switch1",
+};
+
+describe("ArpDeviceRegistry", () => {
+  it("keeps firstSeen fixed and advances lastSeen across repeated upserts", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+    const t1 = t0 + 60_000;
+    registry.upsert(baseDevice, t1);
+
+    const [published] = registry.publish(t1);
+    expect(published.firstSeen).toBe(new Date(t0).toISOString());
+    expect(published.lastSeen).toBe(new Date(t1).toISOString());
+  });
+
+  it("marks a device stale after STALE_THRESHOLD_MS with no re-upsert", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+
+    const justBefore = registry.publish(t0 + STALE_THRESHOLD_MS - 1);
+    expect(justBefore[0].stale).toBe(false);
+
+    const justAfter = registry.publish(t0 + STALE_THRESHOLD_MS + 1);
+    expect(justAfter[0].stale).toBe(true);
+  });
+
+  it("evicts a device after RETENTION_MS with no re-upsert", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+
+    const justBefore = registry.publish(t0 + RETENTION_MS - 1);
+    expect(justBefore).toHaveLength(1);
+
+    const justAfter = registry.publish(t0 + RETENTION_MS + 1);
+    expect(justAfter).toHaveLength(0);
+
+    // Confirms actual deletion, not just filtering: still empty on a later publish.
+    expect(registry.publish(t0 + RETENTION_MS + 2)).toHaveLength(0);
+  });
+
+  it("re-upsert after going stale resets stale back to false and keeps firstSeen", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+    const wentStale = registry.publish(t0 + STALE_THRESHOLD_MS + 1);
+    expect(wentStale[0].stale).toBe(true);
+
+    registry.upsert(baseDevice, t0 + STALE_THRESHOLD_MS + 2);
+    const revived = registry.publish(t0 + STALE_THRESHOLD_MS + 2);
+    expect(revived[0].stale).toBe(false);
+    expect(revived[0].firstSeen).toBe(new Date(t0).toISOString());
+  });
+
+  it("get() returns the raw record fields for merge-enrichment use", () => {
+    const registry = new ArpDeviceRegistry();
+    registry.upsert(baseDevice, 1000);
+    const rec = registry.get("aabbccddeeff");
+    expect(rec?.ips).toEqual(["192.168.1.50"]);
+  });
+});

--- a/backend/src/jobs/arpDeviceRegistry.test.ts
+++ b/backend/src/jobs/arpDeviceRegistry.test.ts
@@ -33,6 +33,9 @@ describe("ArpDeviceRegistry", () => {
     const justBefore = registry.publish(t0 + STALE_THRESHOLD_MS - 1);
     expect(justBefore[0].stale).toBe(false);
 
+    const atExactly = registry.publish(t0 + STALE_THRESHOLD_MS);
+    expect(atExactly[0].stale).toBe(false);
+
     const justAfter = registry.publish(t0 + STALE_THRESHOLD_MS + 1);
     expect(justAfter[0].stale).toBe(true);
   });

--- a/backend/src/jobs/arpDeviceRegistry.ts
+++ b/backend/src/jobs/arpDeviceRegistry.ts
@@ -23,7 +23,10 @@ export class ArpDeviceRegistry {
   }
 
   get(mac: string): ArpDeviceFields | undefined {
-    return this.records.get(mac);
+    const rec = this.records.get(mac);
+    if (!rec) return undefined;
+    const { firstSeen, lastSeen, ...fields } = rec;
+    return fields;
   }
 
   publish(now: number = Date.now()): ArpDiscoveredDevice[] {

--- a/backend/src/jobs/arpDeviceRegistry.ts
+++ b/backend/src/jobs/arpDeviceRegistry.ts
@@ -1,0 +1,47 @@
+import type { ArpDiscoveredDevice } from "@librenms-dash/shared";
+
+export type ArpDeviceFields = Omit<ArpDiscoveredDevice, "firstSeen" | "lastSeen" | "stale">;
+
+interface ArpDeviceRecord extends ArpDeviceFields {
+  firstSeen: number; // epoch ms
+  lastSeen: number;  // epoch ms
+}
+
+export const STALE_THRESHOLD_MS = 15 * 60 * 1000;
+export const RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export class ArpDeviceRegistry {
+  private records = new Map<string, ArpDeviceRecord>();
+
+  upsert(fields: ArpDeviceFields, now: number = Date.now()): void {
+    const existing = this.records.get(fields.mac);
+    this.records.set(fields.mac, {
+      ...fields,
+      firstSeen: existing?.firstSeen ?? now,
+      lastSeen: now,
+    });
+  }
+
+  get(mac: string): ArpDeviceFields | undefined {
+    return this.records.get(mac);
+  }
+
+  publish(now: number = Date.now()): ArpDiscoveredDevice[] {
+    const result: ArpDiscoveredDevice[] = [];
+    for (const [mac, rec] of this.records) {
+      if (now - rec.lastSeen > RETENTION_MS) {
+        this.records.delete(mac);
+        continue;
+      }
+      result.push({
+        ...rec,
+        firstSeen: new Date(rec.firstSeen).toISOString(),
+        lastSeen: new Date(rec.lastSeen).toISOString(),
+        stale: now - rec.lastSeen > STALE_THRESHOLD_MS,
+      });
+    }
+    return result;
+  }
+}
+
+export const arpDeviceRegistry = new ArpDeviceRegistry();

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -903,13 +903,26 @@ export async function pollNdNeighbours() {
   const devices = cache.get<LnmsDevice[]>("devices");
   if (!devices) return;
 
-  // Build mac → hostname map from cached port data
+  // Build mac → hostname map from cached port data. Falls back to a live fetch
+  // when the ports cache entry has expired (TTL.PORTS matches this job's own
+  // poll interval, so a device processed early in pollPortsAndIps's cycle can
+  // otherwise race past expiry right before this runs) — without this, a
+  // managed device's interface MAC would be silently excluded from this map
+  // and wrongly get inserted into the discovered-device registry as unmanaged.
   const macToHostname = new Map<string, string>();
   const hostnameToLocation = new Map<string, string>();
   for (const d of devices) {
     hostnameToLocation.set(d.hostname, d.location || "Unknown");
-    const ports = cache.get<LnmsPort[]>(`ports:${d.hostname}`);
-    if (!ports) continue;
+    let ports: Array<{ ifPhysAddress?: string }> | undefined = cache.get<LnmsPort[]>(`ports:${d.hostname}`) ?? undefined;
+    if (!ports) {
+      try {
+        const res = await librenmsGet<{ ports: Array<{ ifPhysAddress?: string }> }>(`/devices/${d.hostname}/ports`, { columns: "port_id,ifPhysAddress" });
+        ports = res.ports ?? [];
+      } catch {
+        continue;
+      }
+      await delay(50);
+    }
     for (const p of ports) {
       const mac = normalizeMac(p.ifPhysAddress ?? "");
       if (mac && mac.length === 12 && mac !== "000000000000") macToHostname.set(mac, d.hostname);

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -6,7 +6,9 @@ import { makeCidrMatcher } from "../librenms/cidr.js";
 import { ARP_EXCLUDED_SUBNETS, OVERLAY_SUBNET_LIST } from "../config.js";
 import { initWebSession, isWebClientEnabled, fetchRoutes, fetchNdNeighbours, extractIfaceName, extractNextHop, stripHtml } from "../librenms/web-client.js";
 import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsLocation, LnmsAlert, LnmsLink, LnmsArpEntry, LnmsNdEntry } from "../librenms/types.js";
-import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent, TopologyResponse, Site, DeviceSummary, NeighborLink } from "@librenms-dash/shared";
+import type { ArpLink, DeviceRoute, AssetEvent, TopologyResponse, Site, DeviceSummary, NeighborLink } from "@librenms-dash/shared";
+import { arpDeviceRegistry } from "./arpDeviceRegistry.js";
+import type { ArpDeviceFields } from "./arpDeviceRegistry.js";
 
 const STAGGER_MS = 200;
 
@@ -186,7 +188,13 @@ export function buildAndCacheTopology(): void {
     return (fromDevice.location || "Unknown") === (toDevice.location || "Unknown");
   });
 
-  const arpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+  const arpDevices = arpDeviceRegistry.publish();
+
+  const currArpDevices = new Set(arpDevices.map(d => {
+    const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
+    return `${mac} at ${d.location}`;
+  }));
+  prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
 
   const payload: TopologyResponse = {
     sites: [...siteMap.values()],
@@ -648,28 +656,17 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   }
   cache.set("arpLanIps", arpLanIps, TTL.PORTS);
 
-  // Preserve ND-only discovered devices (IPv6-only IPs) that pollNdNeighbours added.
-  // pollArpLinks can't see them — they have no ARP (IPv4) presence — so without this
-  // they get erased every cycle when we overwrite "arpDevices".
-  const prevArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
-  const consolidatedMacs = new Set(arpDevices.map(d => d.mac));
-  const ndOnlyPrev = prevArpDevices.filter(
-    d => !consolidatedMacs.has(d.mac) && d.ips.every(ip => ip.includes(":")),
-  );
-  const finalArpDevices = ndOnlyPrev.length > 0 ? [...arpDevices, ...ndOnlyPrev] : arpDevices;
+  for (const device of arpDevices) {
+    arpDeviceRegistry.upsert(device);
+  }
 
   cache.set("arpLinks", arpLinks, TTL.PORTS);
-  cache.set("arpDevices", finalArpDevices, TTL.PORTS);
-  console.log(`[poller] Cached ${arpLinks.length} ARP links, ${finalArpDevices.length} discovered devices (${arpDevices.length} ARP + ${ndOnlyPrev.length} ND-only), ${arpLanIps.size} ARP-discovered LAN IPs from ${allArpEntries.length} ARP entries`);
+  console.log(`[poller] ARP: upserted ${arpDevices.length} discovered devices, ${arpLinks.length} links, ${arpLanIps.size} LAN IPs from ${allArpEntries.length} ARP entries`);
 
-  const currArpDevices = new Set(finalArpDevices.map(d => {
-    const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
-    return `${mac} at ${d.location}`;
-  }));
-  prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
-  // Always trigger a rebuild — on the first run diffAndLog skips the baseline check
-  // and never sets topologyChangedInCycle, so flushTopologyChanged() would be a no-op,
-  // leaving the topology with the stale arpLinks:[] that pollNdNeighbours wrote.
+  // Always trigger a rebuild — on the first run diffAndLog (inside buildAndCacheTopology)
+  // skips the baseline check and never sets topologyChangedInCycle, so
+  // flushTopologyChanged() would be a no-op, leaving the topology with the stale
+  // arpLinks:[] that pollNdNeighbours wrote.
   topologyChangedInCycle = true;
   flushTopologyChanged();
 }
@@ -685,7 +682,7 @@ function consolidateArpDevices(
   portIdToMac: Map<number, string>,
   portIdToIp: Map<number, string>,
   activeDeviceIds: Set<number>,
-): ArpDiscoveredDevice[] {
+): ArpDeviceFields[] {
   // Phase 1: collect valid (mac, ip) pairs, grouped by location.
   // Scoping by location prevents cross-site merging from swallowing devices.
   const pairsByLocation = new Map<string, Array<{ mac: string; ip: string; deviceId: number; portId: number }>>();
@@ -729,7 +726,7 @@ function consolidateArpDevices(
   }
 
   // Phase 2–4: run union-find per location so deduplication stays within a site
-  const arpDevices: ArpDiscoveredDevice[] = [];
+  const arpDevices: ArpDeviceFields[] = [];
 
   for (const [location, pairs] of pairsByLocation) {
     const siteId = location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
@@ -954,23 +951,24 @@ export async function pollNdNeighbours() {
 
   cache.set("ndGlobalIpv6", ndGlobalIpv6, TTL.PORTS);
 
-  // Merge ND-only unmanaged devices into existing arpDevices
-  const existingArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
-  const macToArpDevice = new Map(existingArpDevices.map((d) => [normalizeMac(d.mac), d]));
-
-  const ndOnlyDevices: ArpDiscoveredDevice[] = [];
+  // Merge ND-only unmanaged devices into the registry
+  let ndOnlyNewCount = 0;
+  let ndEnrichedCount = 0;
   for (const [mac, info] of ndUnmanaged) {
-    const existing = macToArpDevice.get(mac);
+    const existing = arpDeviceRegistry.get(mac);
     if (existing) {
-      // Enrich existing ARP entry with IPv6 addresses
+      // Enrich existing ARP-sourced record with IPv6 addresses
       const ipSet = new Set(existing.ips);
+      const mergedIps = [...existing.ips];
       for (const ip of info.ips) {
-        if (!ipSet.has(ip)) { existing.ips.push(ip); ipSet.add(ip); }
+        if (!ipSet.has(ip)) { mergedIps.push(ip); ipSet.add(ip); }
       }
+      arpDeviceRegistry.upsert({ ...existing, ips: mergedIps });
+      ndEnrichedCount++;
       continue;
     }
     const siteId = info.location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-    ndOnlyDevices.push({
+    arpDeviceRegistry.upsert({
       mac,
       macs: [mac],
       ips: [...info.ips],
@@ -982,13 +980,10 @@ export async function pollNdNeighbours() {
       seenByIp: undefined,
       seenByMac: undefined,
     });
+    ndOnlyNewCount++;
   }
 
-  if (ndOnlyDevices.length > 0) {
-    cache.set("arpDevices", [...existingArpDevices, ...ndOnlyDevices], TTL.PORTS);
-  }
-
-  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyDevices.length} ND-only unmanaged devices`);
+  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyNewCount} new ND-only devices, ${ndEnrichedCount} existing devices enriched with IPv6`);
   buildAndCacheTopology();
 }
 

--- a/backend/src/jobs/poller.ts
+++ b/backend/src/jobs/poller.ts
@@ -415,6 +415,10 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   }
   // Active device IDs — used to restrict which devices can be "seenBy" sources
   const activeDeviceIds = new Set(devices.map((d) => d.device_id));
+  // Enabled devices that are currently down — their LibreNMS ARP cache may be
+  // stale (from before they went down), so entries sourced from them are kept
+  // but flagged via sourceDown rather than treated as fresh sightings.
+  const downDeviceIds = new Set(devices.filter((d) => d.status !== 1).map((d) => d.device_id));
 
   // Map each port_id to its interface name (from the per-device port cache) so
   // ARP links/devices can report which interface a device learned a peer on.
@@ -539,6 +543,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
           fromMac: fromMac ?? entry.mac_address,
           toInterface: ifName || undefined,
           toMac,
+          sourceDown: downDeviceIds.has(entry.device_id),
         });
       }
     } catch {
@@ -588,6 +593,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
       fromMac: mac,
       toInterface: ifName || undefined,
       toMac,
+      sourceDown: downDeviceIds.has(entry.device_id),
     });
   }
 
@@ -637,7 +643,7 @@ async function pollArpLinks(devices: LnmsDevice[], allIps: Map<string, LnmsDevic
   }
 
   // --- Consolidation: union-find to merge MACs sharing an IP and IPs sharing a MAC ---
-  const arpDevices = consolidateArpDevices(allArpEntries, managedIpsByLocation, managedMacsByLocation, deviceIdToHostname, hostnameToLocation, isOverlayIp, portIdToIfName, portIdToMac, portIdToIp, activeDeviceIds);
+  const arpDevices = consolidateArpDevices(allArpEntries, managedIpsByLocation, managedMacsByLocation, deviceIdToHostname, hostnameToLocation, isOverlayIp, portIdToIfName, portIdToMac, portIdToIp, activeDeviceIds, downDeviceIds);
 
   // Discover LAN IPs for managed devices from ARP entries where a device's
   // interface MAC is seen at a non-overlay, non-docker IP. This catches devices
@@ -682,6 +688,7 @@ function consolidateArpDevices(
   portIdToMac: Map<number, string>,
   portIdToIp: Map<number, string>,
   activeDeviceIds: Set<number>,
+  downDeviceIds: Set<number>,
 ): ArpDeviceFields[] {
   // Phase 1: collect valid (mac, ip) pairs, grouped by location.
   // Scoping by location prevents cross-site merging from swallowing devices.
@@ -761,16 +768,17 @@ function consolidateArpDevices(
     }
 
     // Group pairs by component
-    const components = new Map<string, { macs: Set<string>; ips: Set<string>; deviceId: number; portId: number }>();
+    const components = new Map<string, { macs: Set<string>; ips: Set<string>; deviceId: number; portId: number; deviceIds: Set<number> }>();
     for (const p of pairs) {
       const root = find(`mac:${p.mac}`);
       let comp = components.get(root);
       if (!comp) {
-        comp = { macs: new Set(), ips: new Set(), deviceId: p.deviceId, portId: p.portId };
+        comp = { macs: new Set(), ips: new Set(), deviceId: p.deviceId, portId: p.portId, deviceIds: new Set() };
         components.set(root, comp);
       }
       comp.macs.add(p.mac);
       comp.ips.add(p.ip);
+      comp.deviceIds.add(p.deviceId);
     }
 
     // Build output — one entry per component per location
@@ -799,6 +807,10 @@ function consolidateArpDevices(
         return 0;
       });
 
+      // A device seen by at least one currently-up source is never flagged
+      // sourceDown, even if other contributing sources are down.
+      const sourceDown = [...comp.deviceIds].every((id) => downDeviceIds.has(id));
+
       arpDevices.push({
         mac: bestMac,
         macs: macArr,
@@ -810,6 +822,7 @@ function consolidateArpDevices(
         seenByInterface: portIdToIfName.get(comp.portId),
         seenByIp: portIdToIp.get(comp.portId),
         seenByMac: portIdToMac.get(comp.portId),
+        sourceDown,
       });
     }
   }
@@ -979,6 +992,7 @@ export async function pollNdNeighbours() {
       seenByInterface: info.seenByPort,
       seenByIp: undefined,
       seenByMac: undefined,
+      sourceDown: false,
     });
     ndOnlyNewCount++;
   }

--- a/backend/src/routes/devices.ts
+++ b/backend/src/routes/devices.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cache, TTL } from "../cache/store.js";
 import { librenmsGet } from "../librenms/client.js";
 import { findDeviceIps, getOverlayPortSummaries, engine } from "../librenms/overlays.js";
+import { lookupVendor } from "../librenms/oui.js";
 import type { DeviceOverview, DeviceInterface, DeviceRoute } from "@librenms-dash/shared";
 import type { LnmsDevice, LnmsPort, LnmsDeviceIp, LnmsAlert, LnmsHealthSensor } from "../librenms/types.js";
 
@@ -69,6 +70,7 @@ app.get("/:hostname/overview", async (c) => {
     .map((p) => ({
       ifName: p.ifName || p.ifDescr,
       mac: formatMac(p.ifPhysAddress ?? ""),
+      vendor: lookupVendor(p.ifPhysAddress ?? ""),
       ifOperStatus: p.ifOperStatus,
       ips: ipsByPort.get(p.port_id) ?? [],
     }))

--- a/docs/arp-deduplication-and-correlation.md
+++ b/docs/arp-deduplication-and-correlation.md
@@ -4,13 +4,15 @@ This document describes how the backend resolves, deduplicates, and correlates m
 
 ## Overview
 
-The pipeline runs inside `pollArpLinks` (called from `pollPortsAndIps`) and `consolidateArpDevices`. It produces three outputs cached for the topology response:
+The pipeline runs inside `pollArpLinks` (called from `pollPortsAndIps`), `pollNdNeighbours`, and `consolidateArpDevices`. It produces three outputs for the topology response:
 
-| Cache key       | Type                    | Contents                                              |
-|-----------------|-------------------------|-------------------------------------------------------|
-| `arpLinks`      | `ArpLink[]`             | Peer relationships between two managed devices        |
-| `arpDevices`    | `ArpDiscoveredDevice[]` | Consolidated unmanaged devices seen in ARP tables     |
-| `arpLanIps`     | `Map<string, string>`   | LAN IP override for managed devices polled via overlay |
+| Output          | Type                    | Storage                                    | Contents                                              |
+|-----------------|-------------------------|---------------------------------------------|--------------------------------------------------------|
+| `arpLinks`      | `ArpLink[]`             | `cache.set("arpLinks", ...)`, 5-min TTL     | Peer relationships between two managed devices        |
+| `arpDevices`    | `ArpDiscoveredDevice[]` | `ArpDeviceRegistry` (in-memory Map, keyed by MAC, no TTL expiry — see Stage 5) | Consolidated unmanaged devices seen in ARP/ND, with `firstSeen`/`lastSeen`/`stale` |
+| `arpLanIps`     | `Map<string, string>`   | `cache.set("arpLanIps", ...)`, 5-min TTL    | LAN IP override for managed devices polled via overlay |
+
+`arpDevices` is **not** a plain TTL-cached key (unlike the other two) — as of 2026-07-03 it's backed by `ArpDeviceRegistry` (`backend/src/jobs/arpDeviceRegistry.ts`), which persists devices by MAC across poll cycles instead of being rebuilt from scratch each time. See Stage 5.
 
 ---
 
@@ -156,6 +158,23 @@ Managed devices polled exclusively via overlay (VPN) may have no usable LAN IP i
 
 ---
 
+## Stage 5 — Staleness & Retention
+
+**File:** `backend/src/jobs/arpDeviceRegistry.ts`, wired into `pollArpLinks` / `pollNdNeighbours` / `buildAndCacheTopology` in `poller.ts`
+
+A discovered device is no longer dropped the instant it misses a single poll cycle (e.g. a device that's briefly powered off). `ArpDeviceRegistry` is a persistent `Map<mac, record>`:
+
+- **`upsert(fields, now)`** — called once per matching device on every `pollArpLinks` and `pollNdNeighbours` run. Preserves `firstSeen` from the prior record if one exists; always advances `lastSeen` to `now`; replaces all other fields with the current snapshot (ARP is authoritative when both ARP and ND see the same MAC in the same cycle — ND enrichment only adds IPv6 addresses to an existing ARP-sourced record, via `get()` + spread, never wholesale-replaces it).
+- **`publish(now)`** — called from `buildAndCacheTopology()` every cycle. For each record: if `now - lastSeen > 24h` (`RETENTION_MS`), delete it and omit from the result. Otherwise emit it with `stale: now - lastSeen > 15min` (`STALE_THRESHOLD_MS`) and `firstSeen`/`lastSeen` converted to ISO 8601 strings.
+
+15 minutes is 3× the 5-minute poll cadence (see the topology-dataflow project memory / `DEVICE_POLL_MS`/`TTL.PORTS` in `poller.ts`) — long enough that a device isn't flagged stale just from ordinary poll timing jitter.
+
+**Frontend:** a `stale` device's node dims (`ArpDeviceNode.tsx`) but stays fully interactive on hover; its tooltip (`LinkTooltip.tsx`) shows a "Last seen" row only while stale.
+
+**Add/remove notifications:** the `discovered-device` asset-change diff (which drives the toast notifications in `AssetEventToast.tsx`) is computed inside `buildAndCacheTopology()`, against the registry's *post-eviction* published array — not inside `pollArpLinks` against its own per-cycle snapshot. This means: a brand-new MAC fires "added" once; a device going stale fires nothing (it's still in the published array, just dimmed); only actual 24h eviction fires "removed".
+
+---
+
 ## LLDP/CDP Neighbor Link Deduplication
 
 **File:** `backend/src/routes/topology.ts:104–131`
@@ -201,11 +220,22 @@ LibreNMS API
                                           │  Phase 2: union-find per location   │
                                           │  Phase 3: group by component        │
                                           │  Phase 4: pick best MAC             │
-                                          │  → arpDevices[]                     │
+                                          │  → ArpDeviceRegistry.upsert() per   │
+                                          │    device (ARP path); ND path also  │
+                                          │    upserts/enriches the same        │
+                                          │    registry from pollNdNeighbours   │
                                           └─────────────────┬──────────────────┘
                                                             │
                                           ┌─────────────────▼──────────────────┐
                                           │  Stage 4: ARP LAN IP discovery      │
                                           │  → arpLanIps (Map<hostname, ip>)    │
+                                          └─────────────────┬──────────────────┘
+                                                            │
+                                          ┌─────────────────▼──────────────────┐
+                                          │  Stage 5: buildAndCacheTopology()   │
+                                          │  → ArpDeviceRegistry.publish():     │
+                                          │    evict if lastSeen > 24h,         │
+                                          │    stale if lastSeen > 15min        │
+                                          │  → arpDevices[] in TopologyResponse │
                                           └────────────────────────────────────┘
 ```

--- a/docs/superpowers/plans/2026-07-03-discovered-device-lastseen-staleness.md
+++ b/docs/superpowers/plans/2026-07-03-discovered-device-lastseen-staleness.md
@@ -1,0 +1,833 @@
+# Discovered-Device lastSeen / Staleness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track `firstSeen`/`lastSeen` per ARP/ND-discovered device, dim (don't remove) a device for 15 minutes after it stops appearing in polls, and fully remove it only after 24 hours — so a device that's briefly offline (e.g. powered down in a home lab) doesn't vanish from the topology instantly.
+
+**Architecture:** A new backend-owned, in-memory `ArpDeviceRegistry` (module in `backend/src/jobs/arpDeviceRegistry.ts`) replaces the current pattern of overwriting the `arpDevices` array wholesale every poll cycle. `pollArpLinks` and `pollNdNeighbours` upsert into the registry (keeping `firstSeen`, refreshing `lastSeen`); `buildAndCacheTopology()` publishes the registry contents, evicting anything older than 24h and flagging anything older than 15min as `stale`. The frontend threads `stale`/`lastSeen` through the existing layout/render pipeline to dim stale nodes and show a "Last seen" tooltip row.
+
+**Tech Stack:** TypeScript, Hono (backend), React + SVG (frontend), pnpm workspaces, vitest (new, for the registry's pure logic).
+
+## Global Constraints
+
+- No database. The app has no DB dependency anywhere (verified: no `pg`/similar in `backend/package.json`, no DB service in `docker-compose.yaml`). `firstSeen`/`lastSeen` reset on backend restart — same as the rest of the topology cache today. Do not introduce persistence.
+- Stale threshold: **15 minutes** (`STALE_THRESHOLD_MS = 15 * 60 * 1000`).
+- Retention/eviction threshold: **24 hours** (`RETENTION_MS = 24 * 60 * 60 * 1000`).
+- Going stale fires **no** toast/event. Only a genuinely new device ("added") or a 24h-evicted device ("removed") fires an `AssetEvent`.
+- Verify with `docker-compose up -d --build` per project convention (CLAUDE.md) — this is the final gate for every task, in addition to any faster per-task checks.
+- Spec: `docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md`
+
+---
+
+## Task 1: `ArpDiscoveredDevice` type + `ArpDeviceRegistry` module with unit tests
+
+**Files:**
+- Modify: `shared/types.ts:152-163`
+- Create: `backend/src/jobs/arpDeviceRegistry.ts`
+- Create: `backend/src/jobs/arpDeviceRegistry.test.ts`
+- Modify: `backend/package.json` (add `vitest` devDependency + `test` script)
+
+**Interfaces:**
+- Produces: `ArpDeviceFields` (type alias, `Omit<ArpDiscoveredDevice, "firstSeen" | "lastSeen" | "stale">`), `ArpDeviceRegistry` class with `upsert(fields: ArpDeviceFields, now?: number): void`, `get(mac: string): ArpDeviceFields | undefined`, `publish(now?: number): ArpDiscoveredDevice[]`, plus the singleton `arpDeviceRegistry` instance and exported constants `STALE_THRESHOLD_MS`, `RETENTION_MS`. Task 2 imports all of these from `./arpDeviceRegistry.js`.
+
+- [ ] **Step 1: Add `firstSeen`/`lastSeen`/`stale` to the shared type**
+
+Edit `shared/types.ts`, in the `ArpDiscoveredDevice` interface (currently lines 152-163):
+
+```ts
+export interface ArpDiscoveredDevice {
+  mac: string;
+  macs: string[];
+  ips: string[];
+  vendor: string;
+  location: string;
+  siteId: string;
+  seenByHostname: string;
+  seenByInterface?: string;
+  seenByIp?: string;
+  seenByMac?: string;
+  firstSeen: string; // ISO 8601
+  lastSeen: string;  // ISO 8601
+  stale: boolean;
+}
+```
+
+- [ ] **Step 2: Add vitest to the backend package**
+
+Run:
+```bash
+cd /home/jkumar/Librenms-dash && pnpm --filter backend add -D vitest
+```
+
+Then edit `backend/package.json`, add a `test` script to the `"scripts"` block:
+
+```json
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outdir=dist --packages=external --banner:js=\"import{createRequire}from'module';const require=createRequire(import.meta.url);\"",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+```
+
+- [ ] **Step 3: Write the failing test file**
+
+Create `backend/src/jobs/arpDeviceRegistry.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { ArpDeviceRegistry, STALE_THRESHOLD_MS, RETENTION_MS } from "./arpDeviceRegistry.js";
+import type { ArpDeviceFields } from "./arpDeviceRegistry.js";
+
+const baseDevice: ArpDeviceFields = {
+  mac: "aabbccddeeff",
+  macs: ["aabbccddeeff"],
+  ips: ["192.168.1.50"],
+  vendor: "Acme",
+  location: "HQ",
+  siteId: "hq",
+  seenByHostname: "switch1",
+};
+
+describe("ArpDeviceRegistry", () => {
+  it("keeps firstSeen fixed and advances lastSeen across repeated upserts", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+    const t1 = t0 + 60_000;
+    registry.upsert(baseDevice, t1);
+
+    const [published] = registry.publish(t1);
+    expect(published.firstSeen).toBe(new Date(t0).toISOString());
+    expect(published.lastSeen).toBe(new Date(t1).toISOString());
+  });
+
+  it("marks a device stale after STALE_THRESHOLD_MS with no re-upsert", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+
+    const justBefore = registry.publish(t0 + STALE_THRESHOLD_MS - 1);
+    expect(justBefore[0].stale).toBe(false);
+
+    const justAfter = registry.publish(t0 + STALE_THRESHOLD_MS + 1);
+    expect(justAfter[0].stale).toBe(true);
+  });
+
+  it("evicts a device after RETENTION_MS with no re-upsert", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+
+    const justBefore = registry.publish(t0 + RETENTION_MS - 1);
+    expect(justBefore).toHaveLength(1);
+
+    const justAfter = registry.publish(t0 + RETENTION_MS + 1);
+    expect(justAfter).toHaveLength(0);
+
+    // Confirms actual deletion, not just filtering: still empty on a later publish.
+    expect(registry.publish(t0 + RETENTION_MS + 2)).toHaveLength(0);
+  });
+
+  it("re-upsert after going stale resets stale back to false and keeps firstSeen", () => {
+    const registry = new ArpDeviceRegistry();
+    const t0 = 1_000_000;
+    registry.upsert(baseDevice, t0);
+    const wentStale = registry.publish(t0 + STALE_THRESHOLD_MS + 1);
+    expect(wentStale[0].stale).toBe(true);
+
+    registry.upsert(baseDevice, t0 + STALE_THRESHOLD_MS + 2);
+    const revived = registry.publish(t0 + STALE_THRESHOLD_MS + 2);
+    expect(revived[0].stale).toBe(false);
+    expect(revived[0].firstSeen).toBe(new Date(t0).toISOString());
+  });
+
+  it("get() returns the raw record fields for merge-enrichment use", () => {
+    const registry = new ArpDeviceRegistry();
+    registry.upsert(baseDevice, 1000);
+    const rec = registry.get("aabbccddeeff");
+    expect(rec?.ips).toEqual(["192.168.1.50"]);
+  });
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd backend && npx vitest run`
+Expected: FAIL — `Cannot find module './arpDeviceRegistry.js'` (module doesn't exist yet).
+
+- [ ] **Step 5: Implement `ArpDeviceRegistry`**
+
+Create `backend/src/jobs/arpDeviceRegistry.ts`:
+
+```ts
+import type { ArpDiscoveredDevice } from "@librenms-dash/shared";
+
+export type ArpDeviceFields = Omit<ArpDiscoveredDevice, "firstSeen" | "lastSeen" | "stale">;
+
+interface ArpDeviceRecord extends ArpDeviceFields {
+  firstSeen: number; // epoch ms
+  lastSeen: number;  // epoch ms
+}
+
+export const STALE_THRESHOLD_MS = 15 * 60 * 1000;
+export const RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export class ArpDeviceRegistry {
+  private records = new Map<string, ArpDeviceRecord>();
+
+  upsert(fields: ArpDeviceFields, now: number = Date.now()): void {
+    const existing = this.records.get(fields.mac);
+    this.records.set(fields.mac, {
+      ...fields,
+      firstSeen: existing?.firstSeen ?? now,
+      lastSeen: now,
+    });
+  }
+
+  get(mac: string): ArpDeviceFields | undefined {
+    return this.records.get(mac);
+  }
+
+  publish(now: number = Date.now()): ArpDiscoveredDevice[] {
+    const result: ArpDiscoveredDevice[] = [];
+    for (const [mac, rec] of this.records) {
+      if (now - rec.lastSeen > RETENTION_MS) {
+        this.records.delete(mac);
+        continue;
+      }
+      result.push({
+        ...rec,
+        firstSeen: new Date(rec.firstSeen).toISOString(),
+        lastSeen: new Date(rec.lastSeen).toISOString(),
+        stale: now - rec.lastSeen > STALE_THRESHOLD_MS,
+      });
+    }
+    return result;
+  }
+}
+
+export const arpDeviceRegistry = new ArpDeviceRegistry();
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd backend && npx vitest run`
+Expected: PASS — 5 tests passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/types.ts backend/package.json backend/src/jobs/arpDeviceRegistry.ts backend/src/jobs/arpDeviceRegistry.test.ts pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+feat: add ArpDeviceRegistry with firstSeen/lastSeen/stale tracking
+
+Pure in-memory registry that upserts discovered devices by MAC instead
+of overwriting the whole list each poll, so a device survives a brief
+disappearance instead of vanishing instantly. Not yet wired into the
+poller.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire the registry into `poller.ts`
+
+**Files:**
+- Modify: `backend/src/jobs/poller.ts` (imports; `consolidateArpDevices`; `pollArpLinks`; `pollNdNeighbours`; `buildAndCacheTopology`)
+
+**Interfaces:**
+- Consumes: `arpDeviceRegistry`, `ArpDeviceFields`, `STALE_THRESHOLD_MS` (unused directly here, informational), `RETENTION_MS` (same) from `./arpDeviceRegistry.js` (Task 1).
+- Produces: `buildAndCacheTopology()` continues to publish `TopologyResponse.arpDevices` (now with `firstSeen`/`lastSeen`/`stale` populated) — no signature change, so downstream consumers (routes, frontend) are unaffected by this task alone.
+
+- [ ] **Step 1: Update imports**
+
+In `backend/src/jobs/poller.ts`, line 9, remove the now-to-be-unused `ArpDiscoveredDevice` from the type import (it will no longer be referenced directly in this file once the steps below land) and add the registry import. Change:
+
+```ts
+import type { ArpLink, ArpDiscoveredDevice, DeviceRoute, AssetEvent, TopologyResponse, Site, DeviceSummary, NeighborLink } from "@librenms-dash/shared";
+```
+
+to:
+
+```ts
+import type { ArpLink, DeviceRoute, AssetEvent, TopologyResponse, Site, DeviceSummary, NeighborLink } from "@librenms-dash/shared";
+import { arpDeviceRegistry } from "./arpDeviceRegistry.js";
+import type { ArpDeviceFields } from "./arpDeviceRegistry.js";
+```
+
+- [ ] **Step 2: Change `consolidateArpDevices`'s return type**
+
+In `backend/src/jobs/poller.ts`, the function signature (currently around line 688):
+
+```ts
+): ArpDiscoveredDevice[] {
+```
+
+becomes:
+
+```ts
+): ArpDeviceFields[] {
+```
+
+No other change inside `consolidateArpDevices` — its object literals (around lines 805-816) already only populate the `ArpDeviceFields` subset (`mac`, `macs`, `ips`, `vendor`, `location`, `siteId`, `seenByHostname`, `seenByInterface`, `seenByIp`, `seenByMac`), so this is purely a type-annotation fix.
+
+- [ ] **Step 3: Replace the end of `pollArpLinks`**
+
+In `backend/src/jobs/poller.ts`, replace this block (currently lines 651-674):
+
+```ts
+  // Preserve ND-only discovered devices (IPv6-only IPs) that pollNdNeighbours added.
+  // pollArpLinks can't see them — they have no ARP (IPv4) presence — so without this
+  // they get erased every cycle when we overwrite "arpDevices".
+  const prevArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+  const consolidatedMacs = new Set(arpDevices.map(d => d.mac));
+  const ndOnlyPrev = prevArpDevices.filter(
+    d => !consolidatedMacs.has(d.mac) && d.ips.every(ip => ip.includes(":")),
+  );
+  const finalArpDevices = ndOnlyPrev.length > 0 ? [...arpDevices, ...ndOnlyPrev] : arpDevices;
+
+  cache.set("arpLinks", arpLinks, TTL.PORTS);
+  cache.set("arpDevices", finalArpDevices, TTL.PORTS);
+  console.log(`[poller] Cached ${arpLinks.length} ARP links, ${finalArpDevices.length} discovered devices (${arpDevices.length} ARP + ${ndOnlyPrev.length} ND-only), ${arpLanIps.size} ARP-discovered LAN IPs from ${allArpEntries.length} ARP entries`);
+
+  const currArpDevices = new Set(finalArpDevices.map(d => {
+    const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
+    return `${mac} at ${d.location}`;
+  }));
+  prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
+  // Always trigger a rebuild — on the first run diffAndLog skips the baseline check
+  // and never sets topologyChangedInCycle, so flushTopologyChanged() would be a no-op,
+  // leaving the topology with the stale arpLinks:[] that pollNdNeighbours wrote.
+  topologyChangedInCycle = true;
+  flushTopologyChanged();
+}
+```
+
+with:
+
+```ts
+  for (const device of arpDevices) {
+    arpDeviceRegistry.upsert(device);
+  }
+
+  cache.set("arpLinks", arpLinks, TTL.PORTS);
+  console.log(`[poller] ARP: upserted ${arpDevices.length} discovered devices, ${arpLinks.length} links, ${arpLanIps.size} LAN IPs from ${allArpEntries.length} ARP entries`);
+
+  // Always trigger a rebuild — on the first run diffAndLog (inside buildAndCacheTopology)
+  // skips the baseline check and never sets topologyChangedInCycle, so
+  // flushTopologyChanged() would be a no-op, leaving the topology with the stale
+  // arpLinks:[] that pollNdNeighbours wrote.
+  topologyChangedInCycle = true;
+  flushTopologyChanged();
+}
+```
+
+Registry retention (the old "preserve ND-only devices" carve-out) is no longer needed: `arpDeviceRegistry` naturally keeps every MAC it has ever upserted until 24h of silence, so devices only visible via ND are never erased just because this ARP pass didn't see them.
+
+- [ ] **Step 4: Replace the ND-merge block in `pollNdNeighbours`**
+
+In `backend/src/jobs/poller.ts`, replace this block (currently lines 957-989):
+
+```ts
+  // Merge ND-only unmanaged devices into existing arpDevices
+  const existingArpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+  const macToArpDevice = new Map(existingArpDevices.map((d) => [normalizeMac(d.mac), d]));
+
+  const ndOnlyDevices: ArpDiscoveredDevice[] = [];
+  for (const [mac, info] of ndUnmanaged) {
+    const existing = macToArpDevice.get(mac);
+    if (existing) {
+      // Enrich existing ARP entry with IPv6 addresses
+      const ipSet = new Set(existing.ips);
+      for (const ip of info.ips) {
+        if (!ipSet.has(ip)) { existing.ips.push(ip); ipSet.add(ip); }
+      }
+      continue;
+    }
+    const siteId = info.location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    ndOnlyDevices.push({
+      mac,
+      macs: [mac],
+      ips: [...info.ips],
+      vendor: info.vendor || lookupVendor(mac),
+      location: info.location,
+      siteId,
+      seenByHostname: info.seenByHostname,
+      seenByInterface: info.seenByPort,
+      seenByIp: undefined,
+      seenByMac: undefined,
+    });
+  }
+
+  if (ndOnlyDevices.length > 0) {
+    cache.set("arpDevices", [...existingArpDevices, ...ndOnlyDevices], TTL.PORTS);
+  }
+
+  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyDevices.length} ND-only unmanaged devices`);
+  buildAndCacheTopology();
+```
+
+with:
+
+```ts
+  // Merge ND-only unmanaged devices into the registry
+  let ndOnlyNewCount = 0;
+  let ndEnrichedCount = 0;
+  for (const [mac, info] of ndUnmanaged) {
+    const existing = arpDeviceRegistry.get(mac);
+    if (existing) {
+      // Enrich existing ARP-sourced record with IPv6 addresses
+      const ipSet = new Set(existing.ips);
+      const mergedIps = [...existing.ips];
+      for (const ip of info.ips) {
+        if (!ipSet.has(ip)) { mergedIps.push(ip); ipSet.add(ip); }
+      }
+      arpDeviceRegistry.upsert({ ...existing, ips: mergedIps });
+      ndEnrichedCount++;
+      continue;
+    }
+    const siteId = info.location.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    arpDeviceRegistry.upsert({
+      mac,
+      macs: [mac],
+      ips: [...info.ips],
+      vendor: info.vendor || lookupVendor(mac),
+      location: info.location,
+      siteId,
+      seenByHostname: info.seenByHostname,
+      seenByInterface: info.seenByPort,
+      seenByIp: undefined,
+      seenByMac: undefined,
+    });
+    ndOnlyNewCount++;
+  }
+
+  console.log(`[poller] ND: ${totalEntries} entries scanned, ${ndGlobalIpv6.size} managed devices enriched, ${ndOnlyNewCount} new ND-only devices, ${ndEnrichedCount} existing devices enriched with IPv6`);
+  buildAndCacheTopology();
+```
+
+- [ ] **Step 5: Move staleness/eviction/diff logic into `buildAndCacheTopology`**
+
+In `backend/src/jobs/poller.ts`, replace this line (currently line 189):
+
+```ts
+  const arpDevices = cache.get<ArpDiscoveredDevice[]>("arpDevices") ?? [];
+```
+
+with:
+
+```ts
+  const arpDevices = arpDeviceRegistry.publish();
+
+  const currArpDevices = new Set(arpDevices.map(d => {
+    const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
+    return `${mac} at ${d.location}`;
+  }));
+  prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
+```
+
+This is the fix for the eviction-toast gap identified during design review: the diff now runs against the registry's own post-eviction snapshot (computed inside `buildAndCacheTopology`, which every eviction passes through), instead of `pollArpLinks`'s local per-cycle snapshot which never observed eviction.
+
+- [ ] **Step 6: Type-check the backend**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: no errors. (If `ArpDiscoveredDevice` or `normalizeMac` show as unused-import errors, remove them from the relevant import lines — `normalizeMac` is still used elsewhere in `pollNdNeighbours`/`pollArpLinks` for MAC lookups, so it should remain; only `ArpDiscoveredDevice` is expected to become unused, which Step 1 already handled.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/jobs/poller.ts
+git commit -m "$(cat <<'EOF'
+feat: wire ArpDeviceRegistry into poller, fix eviction-toast gap
+
+pollArpLinks and pollNdNeighbours now upsert into the registry instead
+of overwriting the arpDevices cache key each cycle. buildAndCacheTopology
+publishes the registry (with staleness/eviction applied) and now owns
+the discovered-device add/remove diff, so the "removed" toast actually
+fires on 24h eviction instead of never firing.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Backend end-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full workspace build**
+
+Run: `cd /home/jkumar/Librenms-dash && docker-compose up -d --build`
+Expected: build succeeds, container starts and stays up (`docker-compose ps` shows `librenms-dash` as `Up`).
+
+- [ ] **Step 2: Confirm poller logs show the new registry-based flow**
+
+Run: `docker-compose logs -f librenms-dash | grep -E "\[poller\] (ARP|ND):"`
+Expected (within a few minutes, once poll cycles run): lines like
+```
+[poller] ARP: upserted N discovered devices, M links, K LAN IPs from ... ARP entries
+[poller] ND: X entries scanned, Y managed devices enriched, Z new ND-only devices, W existing devices enriched with IPv6
+```
+No errors or unhandled rejections in the logs.
+
+- [ ] **Step 3: Confirm the API payload carries the new fields**
+
+Run: `curl -s http://localhost:3001/api/topology | node -e "const d=JSON.parse(require('fs').readFileSync(0)); console.log(JSON.stringify(d.arpDevices[0], null, 2))"`
+Expected: the first discovered device object includes `firstSeen`, `lastSeen` (ISO 8601 strings) and `stale: false` (assuming it was just polled).
+
+---
+
+## Task 4: Frontend — thread `stale`/`lastSeen`, dim stale nodes, show "Last seen" in tooltip
+
+**Files:**
+- Modify: `frontend/src/hooks/useForceLayout.ts:68-79` (interface), `:365-380` (construction)
+- Modify: `frontend/src/components/ArpDeviceNode.tsx`
+- Modify: `frontend/src/components/DevicePopover.tsx` (export existing `formatTimestamp` helper)
+- Modify: `frontend/src/components/LinkTooltip.tsx`
+- Modify: `frontend/src/components/TopologyMap.tsx` (two `LinkTooltipData` construction sites for `arp-device`, and the `ArpDeviceNode` render call)
+
+**Interfaces:**
+- Consumes: `TopologyResponse.arpDevices[].stale: boolean` and `.lastSeen: string` (Task 2/3).
+- Produces: `ArpDeviceLayoutNode.stale: boolean`, `.lastSeen: string` for `TopologyMap.tsx` to read; `LinkTooltipData.stale?: boolean`, `.lastSeen?: string` for `LinkTooltip.tsx` to render.
+
+- [ ] **Step 1: Thread `stale`/`lastSeen` through `ArpDeviceLayoutNode`**
+
+In `frontend/src/hooks/useForceLayout.ts`, the interface (currently lines 68-79):
+
+```ts
+export interface ArpDeviceLayoutNode {
+  mac: string;
+  ips: string[];
+  vendor: string;
+  siteId: string;
+  seenByHostname: string;
+  seenByInterface?: string;
+  seenByIp?: string;
+  seenByMac?: string;
+  x: number;
+  y: number;
+}
+```
+
+becomes:
+
+```ts
+export interface ArpDeviceLayoutNode {
+  mac: string;
+  ips: string[];
+  vendor: string;
+  siteId: string;
+  seenByHostname: string;
+  seenByInterface?: string;
+  seenByIp?: string;
+  seenByMac?: string;
+  stale: boolean;
+  lastSeen: string;
+  x: number;
+  y: number;
+}
+```
+
+And its construction (currently lines 368-379):
+
+```ts
+        allArpDeviceNodes.push({
+          mac: ad.mac,
+          ips: ad.ips,
+          vendor: ad.vendor,
+          siteId: site.id,
+          seenByHostname: ad.seenByHostname,
+          seenByInterface: ad.seenByInterface,
+          seenByIp: ad.seenByIp,
+          seenByMac: ad.seenByMac,
+          x: arpStartX + ARP_NODE_W / 2 + col * (ARP_NODE_W + ARP_NODE_GAP_X),
+          y: arpStartY + ARP_SECTION_LABEL_H + ARP_SECTION_PAD + ARP_NODE_H / 2 + row * (ARP_NODE_H + ARP_NODE_GAP_Y),
+        });
+```
+
+becomes:
+
+```ts
+        allArpDeviceNodes.push({
+          mac: ad.mac,
+          ips: ad.ips,
+          vendor: ad.vendor,
+          siteId: site.id,
+          seenByHostname: ad.seenByHostname,
+          seenByInterface: ad.seenByInterface,
+          seenByIp: ad.seenByIp,
+          seenByMac: ad.seenByMac,
+          stale: ad.stale,
+          lastSeen: ad.lastSeen,
+          x: arpStartX + ARP_NODE_W / 2 + col * (ARP_NODE_W + ARP_NODE_GAP_X),
+          y: arpStartY + ARP_SECTION_LABEL_H + ARP_SECTION_PAD + ARP_NODE_H / 2 + row * (ARP_NODE_H + ARP_NODE_GAP_Y),
+        });
+```
+
+- [ ] **Step 2: Dim `ArpDeviceNode` when stale**
+
+`node: ArpDeviceLayoutNode` already carries `stale` (from Step 1), so no prop-type change is needed — only the render logic changes.
+
+In `frontend/src/components/ArpDeviceNode.tsx`, change (currently line 26):
+
+```ts
+  const active = isHovered || highlighted || searchMatch;
+```
+
+to:
+
+```ts
+  const active = isHovered || highlighted || searchMatch;
+  const dimmed = node.stale && !active;
+```
+
+and change the box `<rect>` (currently lines 59-71):
+
+```ts
+      <rect
+        x={x}
+        y={y}
+        width={BOX_W}
+        height={BOX_H}
+        rx={6}
+        fill={active ? "#1e293b" : "#0f172a"}
+        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : 0.65}
+        stroke={searchMatch ? "#facc15" : "#fbbf24"}
+        strokeWidth={searchMatch ? 2.5 : active ? 1.5 : 1}
+        strokeOpacity={active ? 0.8 : 0.4}
+        className={searchMatch ? "search-match-box" : undefined}
+      />
+```
+
+to:
+
+```ts
+      <rect
+        x={x}
+        y={y}
+        width={BOX_W}
+        height={BOX_H}
+        rx={6}
+        fill={active ? "#1e293b" : "#0f172a"}
+        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : dimmed ? 0.3 : 0.65}
+        stroke={searchMatch ? "#facc15" : "#fbbf24"}
+        strokeWidth={searchMatch ? 2.5 : active ? 1.5 : 1}
+        strokeOpacity={active ? 0.8 : dimmed ? 0.2 : 0.4}
+        className={searchMatch ? "search-match-box" : undefined}
+      />
+```
+
+Also add `stale?: boolean;` — no, `stale` is a required field on `ArpDeviceLayoutNode` (set in Step 1), so `node.stale` is always defined; no prop-type change needed on `Props` since `node: ArpDeviceLayoutNode` already carries it.
+
+- [ ] **Step 3: Export the existing relative-time formatter**
+
+In `frontend/src/components/DevicePopover.tsx`, the private helper (currently around lines 30-43):
+
+```ts
+function formatTimestamp(ts: string): string {
+```
+
+becomes:
+
+```ts
+export function formatTimestamp(ts: string): string {
+```
+
+(No other change — reused as-is to avoid duplicating relative-time logic (DRY). It already handles ISO 8601 strings correctly since `ts.replace(" ", "T")` is a no-op when "T" is already present.)
+
+- [ ] **Step 4: Add `stale`/`lastSeen` to `LinkTooltipData` and render a conditional row**
+
+In `frontend/src/components/LinkTooltip.tsx`, add to the `LinkTooltipData` interface (currently lines 27-30):
+
+```ts
+  // ARP discovered device
+  interface?: string;
+  vendor?: string;
+  sourceMac?: string;
+```
+
+becomes:
+
+```ts
+  // ARP discovered device
+  interface?: string;
+  vendor?: string;
+  sourceMac?: string;
+  stale?: boolean;
+  lastSeen?: string;
+```
+
+Add the import at the top (line 1):
+
+```ts
+import { Copyable } from "./Copyable";
+```
+
+becomes:
+
+```ts
+import { Copyable } from "./Copyable";
+import { formatTimestamp } from "./DevicePopover";
+```
+
+And in the `arp-device` table body, add a "Last seen" row after the MAC row (currently line 94):
+
+```ts
+            <Row label="MAC" value={data.mac ?? "—"} mono copyable />
+          </tbody>
+        </table>
+      ) : data.type === "arp" ? (
+```
+
+becomes:
+
+```ts
+            <Row label="MAC" value={data.mac ?? "—"} mono copyable />
+            {data.stale && data.lastSeen && <Row label="Last seen" value={formatTimestamp(data.lastSeen)} />}
+          </tbody>
+        </table>
+      ) : data.type === "arp" ? (
+```
+
+- [ ] **Step 5: Pass `stale`/`lastSeen` from `TopologyMap.tsx` into both tooltip builders and the node**
+
+In `frontend/src/components/TopologyMap.tsx`, the connector-line hover tooltip (currently lines 1182-1197):
+
+```ts
+                  onMouseEnter={(e) => showLinkTooltip(key, {
+                    type: "arp-device",
+                    screenX: e.clientX,
+                    screenY: e.clientY,
+                    sourceHostname: ad.seenByHostname,
+                    targetHostname: ad.mac,
+                    sourceDisplayName: displayName(ad.seenByHostname),
+                    targetDisplayName: ad.vendor || "Unknown device",
+                    color: ARP_COLOR,
+                    sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+                    targetIps: ad.ips,
+                    mac: formatMac(ad.mac),
+                    interface: ad.seenByInterface,
+                    sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
+                    vendor: ad.vendor,
+                  })}
+```
+
+becomes:
+
+```ts
+                  onMouseEnter={(e) => showLinkTooltip(key, {
+                    type: "arp-device",
+                    screenX: e.clientX,
+                    screenY: e.clientY,
+                    sourceHostname: ad.seenByHostname,
+                    targetHostname: ad.mac,
+                    sourceDisplayName: displayName(ad.seenByHostname),
+                    targetDisplayName: ad.vendor || "Unknown device",
+                    color: ARP_COLOR,
+                    sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+                    targetIps: ad.ips,
+                    mac: formatMac(ad.mac),
+                    interface: ad.seenByInterface,
+                    sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
+                    vendor: ad.vendor,
+                    stale: ad.stale,
+                    lastSeen: ad.lastSeen,
+                  })}
+```
+
+And the node hover tooltip builder (currently lines 1216-1231):
+
+```ts
+            const tooltip = (e: { clientX: number; clientY: number }): LinkTooltipData => ({
+              type: "arp-device",
+              screenX: e.clientX,
+              screenY: e.clientY,
+              sourceHostname: ad.seenByHostname,
+              targetHostname: ad.mac,
+              sourceDisplayName: displayName(ad.seenByHostname),
+              targetDisplayName: ad.vendor || "Unknown device",
+              color: ARP_COLOR,
+              sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+              targetIps: ad.ips,
+              mac: formatMac(ad.mac),
+              interface: ad.seenByInterface,
+              sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
+              vendor: ad.vendor,
+            });
+```
+
+becomes:
+
+```ts
+            const tooltip = (e: { clientX: number; clientY: number }): LinkTooltipData => ({
+              type: "arp-device",
+              screenX: e.clientX,
+              screenY: e.clientY,
+              sourceHostname: ad.seenByHostname,
+              targetHostname: ad.mac,
+              sourceDisplayName: displayName(ad.seenByHostname),
+              targetDisplayName: ad.vendor || "Unknown device",
+              color: ARP_COLOR,
+              sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
+              targetIps: ad.ips,
+              mac: formatMac(ad.mac),
+              interface: ad.seenByInterface,
+              sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
+              vendor: ad.vendor,
+              stale: ad.stale,
+              lastSeen: ad.lastSeen,
+            });
+```
+
+The `<ArpDeviceNode node={ad} ... />` call (currently line 1233-1241) needs no change — `node` is already the full `ArpDeviceLayoutNode`, which now carries `stale` (Step 1), and `ArpDeviceNode` reads `node.stale` directly (Step 2).
+
+- [ ] **Step 6: Type-check the frontend**
+
+Run: `cd frontend && npx tsc -b`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/hooks/useForceLayout.ts frontend/src/components/ArpDeviceNode.tsx frontend/src/components/DevicePopover.tsx frontend/src/components/LinkTooltip.tsx frontend/src/components/TopologyMap.tsx
+git commit -m "$(cat <<'EOF'
+feat: dim stale discovered devices and show last-seen in tooltip
+
+Threads stale/lastSeen from the topology payload through the layout
+hook into ArpDeviceNode (dimmed when stale, still fully interactive on
+hover) and LinkTooltip (a "Last seen" row shown only for stale
+devices). Reuses DevicePopover's existing relative-time formatter.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Full-stack manual verification in the browser
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and start**
+
+Run: `cd /home/jkumar/Librenms-dash && docker-compose up -d --build`
+Expected: build succeeds, container up.
+
+- [ ] **Step 2: Confirm live devices render unchanged**
+
+Open the app in a browser, enable the "Discovered" layer, hover a discovered device that's currently live. Confirm: node renders at normal opacity (not dimmed), tooltip does NOT show a "Last seen" row (since `stale` is false for a freshly-polled device).
+
+- [ ] **Step 3: Confirm dimming and tooltip for a stale device**
+
+This requires either waiting ~15 minutes for a real device to stop responding, or a quick local smoke test: temporarily lower `STALE_THRESHOLD_MS` in `backend/src/jobs/arpDeviceRegistry.ts` to e.g. `10 * 1000` (10 seconds), rebuild (`docker-compose up -d --build`), wait ~10 seconds without that device's poll refreshing (or just observe any device that hasn't been re-confirmed yet on first startup, since the registry starts empty and the first poll cycle's devices won't be "stale" until 10s pass without a second poll). Confirm: the node dims, and hovering shows a "Last seen: Xs ago"-style row. **Revert the temporary threshold change** back to `15 * 60 * 1000` before finishing, and rebuild once more to confirm the revert is clean.
+
+- [ ] **Step 4: Confirm no regressions in existing features**
+
+Spot-check: managed-device nodes, LLDP/CDP links, overlay links, and the existing ARP connector lines all still render and hover correctly (unrelated to this change, but touched files are shared with other tooltip/layout code).

--- a/docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md
+++ b/docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md
@@ -57,7 +57,7 @@ function upsertArpDevice(fields: Omit<ArpDeviceRecord, "firstSeen" | "lastSeen">
 Done once per cycle in `buildAndCacheTopology()`:
 
 ```ts
-const STALE_THRESHOLD_MS = 15 * 60 * 1000;      // 3x ND poll cycle (TTL.PORTS = 5min)
+const STALE_THRESHOLD_MS = 15 * 60 * 1000;      // 3x poll cycle (TTL.PORTS = DEVICE_POLL_MS = 5min)
 const RETENTION_MS = 24 * 60 * 60 * 1000;        // full removal
 
 const now = Date.now();
@@ -74,14 +74,27 @@ for (const [mac, rec] of arpDeviceRegistry) {
     stale: now - rec.lastSeen > STALE_THRESHOLD_MS,
   });
 }
+
+const currArpDevices = new Set(arpDevices.map(d => {
+  const mac = d.mac.replace(/(.{2})(?=.)/g, "$1:");
+  return `${mac} at ${d.location}`;
+}));
+prevAssets.arpDevices = diffAndLog("discovered-device", prevAssets.arpDevices, currArpDevices);
 ```
 
-- **15-minute stale threshold** (3× the 5-minute ND poll cycle) avoids flicker for ND-only devices, which would otherwise be falsely marked stale between their own poll passes.
+- **15-minute stale threshold**: both `pollArpLinks` (via `pollPortsAndIps`) and `pollNdNeighbours` run on the same 5-minute cadence (`TTL.PORTS` = `DEVICE_POLL_MS` = 5 min — confirmed in code; there is no fast/slow split between ARP and ND polling). 15 min = 3× that cycle, giving two full missed cycles of buffer before dimming, from either source.
 - **24-hour retention** before full removal from the registry and the published `arpDevices` array.
 
-### 3. Side effect: `AssetEvent` toast behavior improves for free
+### 3. Relocating the discovered-device diff/toast logic (fixes a real gap)
 
-`diffAndLog("discovered-device", ...)` (`poller.ts:669`) diffs the published `arpDevices` set cycle-to-cycle to fire "added"/"removed" toasts. Since the published array now includes stale-but-retained devices, "removed" only fires on actual 24h eviction (not on a single missed cycle), and "added" only fires on a genuinely first-ever sighting (not every time a stale device gets reconfirmed within the 24h window). No additional code needed — this falls out of the data model change.
+Today, `diffAndLog("discovered-device", ...)` lives inside `pollArpLinks` (`poller.ts:665-669`), diffing against that function's own local `finalArpDevices` snapshot. That snapshot is unrelated to the registry-based eviction in part 2 — if left in place, the 24h-eviction "removed" toast would never fire, because `pollArpLinks` never observes the eviction (it only runs its own ARP-consolidation pass).
+
+**Fix**: delete the `currArpDevices`/`diffAndLog` block from `pollArpLinks` entirely (lines 665-669). The diff now lives inside `buildAndCacheTopology()` (shown in the code block above), computed from the final post-eviction `arpDevices` array right before it's published. `pollArpLinks` keeps its unconditional `topologyChangedInCycle = true; flushTopologyChanged();` (`poller.ts:673-674`) unchanged — that's an unrelated cold-start guard for `arpLinks`, not tied to device diffing.
+
+This one relocation gives correct behavior for all three cases:
+- **New device** (via ARP or ND) → appears in `arpDevices` next `buildAndCacheTopology()` run → `diffAndLog` fires **added**.
+- **Device evicted at 24h** → disappears from `arpDevices` the cycle it's evicted → `diffAndLog` fires **removed**.
+- **Device goes stale** (15-min threshold) → stays in `arpDevices` (only `stale` flips true) → set membership unchanged → **no event fires**. Confirmed as the desired behavior: staleness is a silent visual-only transition (dimming), not a toast — avoids noise from a device flickering near the 15-min boundary. Only genuine add/24h-remove are toast-worthy.
 
 ### 4. Shared types
 
@@ -131,7 +144,7 @@ SSE topology-changed → frontend setQueryData → useForceLayout threads stale/
 | File | Change |
 |------|--------|
 | `shared/types.ts` | `ArpDiscoveredDevice` gains `firstSeen`, `lastSeen`, `stale` |
-| `backend/src/jobs/poller.ts` | New `arpDeviceRegistry` + `upsertArpDevice()`; `pollArpLinks`/`pollNdNeighbours` upsert instead of overwrite; `buildAndCacheTopology()` computes staleness/eviction; removes ND-only-preservation carve-out |
+| `backend/src/jobs/poller.ts` | New `arpDeviceRegistry` + `upsertArpDevice()`; `pollArpLinks`/`pollNdNeighbours` upsert instead of overwrite; `buildAndCacheTopology()` computes staleness/eviction and now owns the `discovered-device` diff/toast logic (moved out of `pollArpLinks`); removes ND-only-preservation carve-out |
 | `frontend/src/hooks/useForceLayout.ts` | Thread `stale`/`lastSeen` into `ArpDeviceLayoutNode` |
 | `frontend/src/components/ArpDeviceNode.tsx` | `stale` prop dims the node when not hovered/highlighted |
 | `frontend/src/components/TopologyMap.tsx` | Pass `stale`/`lastSeen` into `LinkTooltipData` for discovered-device hover |
@@ -147,5 +160,5 @@ SSE topology-changed → frontend setQueryData → useForceLayout threads stale/
 ## Trade-offs
 
 - **No cross-restart persistence**: a backend restart resets all `firstSeen`/`lastSeen` history, same as the rest of the topology cache today. Accepted — adding a database is out of scope (see Non-Goals).
-- **Single wall-clock stale threshold, not per-source**: an ARP-only device could theoretically be flagged stale a little later than the instant it truly vanishes (up to 15 min), since the threshold is sized for the slower ND cadence. Simpler than tracking per-source "reconfirmed this cycle" state; acceptable for v1.
+- **Single wall-clock stale threshold, not per-source**: any device could be flagged stale up to ~15 min after it actually stopped appearing, rather than the instant it's confirmed missing from a single poll pass. Simpler than tracking per-source "reconfirmed this cycle" state; acceptable for v1.
 - **Registry grows unbounded between evictions**: in practice bounded by the number of distinct MACs seen on the network in any 24h window, which is the same order of magnitude as today's `arpDevices` array — no new unbounded-growth risk.

--- a/docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md
+++ b/docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md
@@ -1,0 +1,151 @@
+# Discovered-Device lastSeen / Staleness Tracking
+
+**Date:** 2026-07-03
+**Status:** Approved
+
+## Problem
+
+`ArpDiscoveredDevice` (ARP/ND-discovered, unmanaged devices shown in the topology) carries no timestamp of any kind. The `arpDevices` array is fully rebuilt from the live ARP/ND snapshot every poll cycle, so a device that misses a single cycle — e.g. powered off temporarily in a home-lab scenario — simply vanishes from the topology instantly, with no record it was ever seen or how long ago.
+
+## Goals
+
+1. Track `firstSeen` / `lastSeen` per discovered device.
+2. Don't drop a device from the topology the instant one poll cycle misses it — keep it visible (dimmed) for a grace period, then remove it.
+3. Surface "last seen" in the UI for devices that have gone stale.
+
+## Non-Goals
+
+- Cross-restart persistence. The app has no database (verified: no DB dependency in `backend/package.json`, no DB service in `docker-compose.yaml` — LibreNMS's API is the source of truth, everything else lives in an in-memory `TTLCache`). Introducing a database is out of scope for this feature; `firstSeen`/`lastSeen` reset on backend restart, consistent with how `arpDevices`/`assetEvents` already behave.
+- "First seen" UI display. The field is persisted (cheap, and useful later) but not shown in the tooltip in this iteration.
+- Per-source (ARP vs ND) staleness thresholds. A single wall-clock threshold is used instead of tracking "was this MAC reconfirmed in the most recent pass of each poll type."
+
+---
+
+## Design
+
+### 1. Backend: persistent registry replaces per-cycle overwrite
+
+**`backend/src/jobs/poller.ts`** — new module-level store:
+
+```ts
+interface ArpDeviceRecord extends Omit<ArpDiscoveredDevice, "firstSeen" | "lastSeen" | "stale"> {
+  firstSeen: number; // epoch ms
+  lastSeen: number;  // epoch ms
+}
+
+const arpDeviceRegistry = new Map<string, ArpDeviceRecord>(); // keyed by normalized MAC
+
+function upsertArpDevice(fields: Omit<ArpDeviceRecord, "firstSeen" | "lastSeen">) {
+  const now = Date.now();
+  const existing = arpDeviceRegistry.get(fields.mac);
+  arpDeviceRegistry.set(fields.mac, {
+    ...fields,
+    firstSeen: existing?.firstSeen ?? now,
+    lastSeen: now,
+  });
+}
+```
+
+**`pollArpLinks`** (`poller.ts:632` area): after `consolidateArpDevices` produces this cycle's ARP-visible devices, call `upsertArpDevice()` for each instead of writing the array directly to `cache`. Devices absent from this cycle's ARP snapshot are left untouched in the registry — their `lastSeen` just ages.
+
+**`pollNdNeighbours`** (`poller.ts:890` area): same treatment for each `ndUnmanaged` entry — call `upsertArpDevice()`.
+
+**Removes existing special-case code**: the "preserve ND-only discovered devices" carve-out (`poller.ts:651-659` — `prevArpDevices`, `consolidatedMacs`, `ndOnlyPrev`, `finalArpDevices`) exists only because today's code has no proper merge-by-MAC. The registry retains ND-only devices naturally, so this ~10-line block is deleted, not extended.
+
+### 2. Staleness computation & eviction
+
+Done once per cycle in `buildAndCacheTopology()`:
+
+```ts
+const STALE_THRESHOLD_MS = 15 * 60 * 1000;      // 3x ND poll cycle (TTL.PORTS = 5min)
+const RETENTION_MS = 24 * 60 * 60 * 1000;        // full removal
+
+const now = Date.now();
+const arpDevices: ArpDiscoveredDevice[] = [];
+for (const [mac, rec] of arpDeviceRegistry) {
+  if (now - rec.lastSeen > RETENTION_MS) {
+    arpDeviceRegistry.delete(mac);
+    continue;
+  }
+  arpDevices.push({
+    ...rec,
+    firstSeen: new Date(rec.firstSeen).toISOString(),
+    lastSeen: new Date(rec.lastSeen).toISOString(),
+    stale: now - rec.lastSeen > STALE_THRESHOLD_MS,
+  });
+}
+```
+
+- **15-minute stale threshold** (3× the 5-minute ND poll cycle) avoids flicker for ND-only devices, which would otherwise be falsely marked stale between their own poll passes.
+- **24-hour retention** before full removal from the registry and the published `arpDevices` array.
+
+### 3. Side effect: `AssetEvent` toast behavior improves for free
+
+`diffAndLog("discovered-device", ...)` (`poller.ts:669`) diffs the published `arpDevices` set cycle-to-cycle to fire "added"/"removed" toasts. Since the published array now includes stale-but-retained devices, "removed" only fires on actual 24h eviction (not on a single missed cycle), and "added" only fires on a genuinely first-ever sighting (not every time a stale device gets reconfirmed within the 24h window). No additional code needed — this falls out of the data model change.
+
+### 4. Shared types
+
+**`shared/types.ts`** — `ArpDiscoveredDevice` gains:
+
+```ts
+export interface ArpDiscoveredDevice {
+  // ...existing fields unchanged...
+  firstSeen: string;  // ISO 8601
+  lastSeen: string;   // ISO 8601
+  stale: boolean;
+}
+```
+
+### 5. Frontend
+
+**`frontend/src/hooks/useForceLayout.ts`**: thread `stale` and `lastSeen` through `ArpDeviceLayoutNode` (`:68-71`) and its construction (`:369-371`), the same way `vendor`/`mac`/`ips` already flow from `TopologyResponse.arpDevices` into the layout node.
+
+**`frontend/src/components/ArpDeviceNode.tsx`**: add a `stale?: boolean` prop. When `stale && !active`, reduce `fillOpacity`/`strokeOpacity` below their current baseline (box ~0.65 → ~0.3, border ~0.4 → ~0.2). Hovering (`isHovered`) restores full visibility exactly like the existing `active` branch — a stale device is still fully inspectable, just visually deprioritized when not interacted with.
+
+**`frontend/src/components/TopologyMap.tsx`** (where `LinkTooltipData` is built for a hovered `ArpDeviceNode`, `~1186-1228`) and **`frontend/src/components/LinkTooltip.tsx`**: add a "Last seen" `Row`, rendered only when `stale` is true. Format as relative time ("3h ago") with the exact ISO timestamp in a `title` attribute for precision on hover.
+
+**No changes** to `AssetEventToast.tsx` — it renders whatever `AssetEvent`s arrive over SSE; part 3's change to *when* those fire is transparent to it.
+
+---
+
+## Data Flow (After)
+
+```
+pollArpLinks / pollNdNeighbours (independent cadences)
+  → upsertArpDevice() per discovered MAC: keep firstSeen, refresh lastSeen + fields
+  → arpDeviceRegistry (module-level Map, in-memory, no cross-restart persistence)
+
+buildAndCacheTopology() (every cycle)
+  → evict registry entries with lastSeen > 24h old
+  → compute stale = lastSeen > 15min old
+  → publish ArpDiscoveredDevice[] with firstSeen/lastSeen/stale into TopologyResponse
+
+SSE topology-changed → frontend setQueryData → useForceLayout threads stale/lastSeen
+  → ArpDeviceNode dims when stale, LinkTooltip shows "Last seen: Xh ago"
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `shared/types.ts` | `ArpDiscoveredDevice` gains `firstSeen`, `lastSeen`, `stale` |
+| `backend/src/jobs/poller.ts` | New `arpDeviceRegistry` + `upsertArpDevice()`; `pollArpLinks`/`pollNdNeighbours` upsert instead of overwrite; `buildAndCacheTopology()` computes staleness/eviction; removes ND-only-preservation carve-out |
+| `frontend/src/hooks/useForceLayout.ts` | Thread `stale`/`lastSeen` into `ArpDeviceLayoutNode` |
+| `frontend/src/components/ArpDeviceNode.tsx` | `stale` prop dims the node when not hovered/highlighted |
+| `frontend/src/components/TopologyMap.tsx` | Pass `stale`/`lastSeen` into `LinkTooltipData` for discovered-device hover |
+| `frontend/src/components/LinkTooltip.tsx` | Conditional "Last seen" row |
+
+---
+
+## Testing
+
+- **Backend unit test**: exercise `upsertArpDevice()` / the eviction logic directly (inject/mock `Date.now()`) — assert `firstSeen` stays fixed across repeated upserts of the same MAC, `lastSeen` advances, `stale` flips at the 15-minute boundary, and the entry is deleted at the 24-hour boundary.
+- **Manual verification**: `docker-compose up -d --build`, confirm a live device renders normally, and confirm (via temporarily patching the stale/retention constants down for a local test run, or waiting out a real cycle) that a device that stops appearing in ARP/ND dims after 15 minutes and is removed after 24 hours, with the tooltip showing a correct relative "last seen" time.
+
+## Trade-offs
+
+- **No cross-restart persistence**: a backend restart resets all `firstSeen`/`lastSeen` history, same as the rest of the topology cache today. Accepted — adding a database is out of scope (see Non-Goals).
+- **Single wall-clock stale threshold, not per-source**: an ARP-only device could theoretically be flagged stale a little later than the instant it truly vanishes (up to 15 min), since the threshold is sized for the slower ND cadence. Simpler than tracking per-source "reconfirmed this cycle" state; acceptable for v1.
+- **Registry grows unbounded between evictions**: in practice bounded by the number of distinct MACs seen on the network in any 24h window, which is the same order of magnitude as today's `arpDevices` array — no new unbounded-growth risk.

--- a/frontend/src/components/ArpDeviceNode.tsx
+++ b/frontend/src/components/ArpDeviceNode.tsx
@@ -24,6 +24,7 @@ export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, on
   const ipTrunc = ip0.length > 20 ? ip0.slice(0, 19) + "…" : ip0;
   const ipDisplay = node.ips.length > 1 ? `${ipTrunc} +${node.ips.length - 1}` : ipTrunc;
   const active = isHovered || highlighted || searchMatch;
+  const dimmed = node.stale && !active;
 
   const handleEnter = useCallback((e: React.MouseEvent) => {
     setIsHovered(true);
@@ -63,10 +64,10 @@ export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, on
         height={BOX_H}
         rx={6}
         fill={active ? "#1e293b" : "#0f172a"}
-        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : 0.65}
+        fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : dimmed ? 0.3 : 0.65}
         stroke={searchMatch ? "#facc15" : "#fbbf24"}
         strokeWidth={searchMatch ? 2.5 : active ? 1.5 : 1}
-        strokeOpacity={active ? 0.8 : 0.4}
+        strokeOpacity={active ? 0.8 : dimmed ? 0.2 : 0.4}
         className={searchMatch ? "search-match-box" : undefined}
       />
       {/* Vendor */}

--- a/frontend/src/components/ArpDeviceNode.tsx
+++ b/frontend/src/components/ArpDeviceNode.tsx
@@ -25,6 +25,7 @@ export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, on
   const ipDisplay = node.ips.length > 1 ? `${ipTrunc} +${node.ips.length - 1}` : ipTrunc;
   const active = isHovered || highlighted || searchMatch;
   const dimmed = node.stale && !active;
+  const accentColor = searchMatch ? "#facc15" : node.sourceDown ? "#f87171" : "#fbbf24";
 
   const handleEnter = useCallback((e: React.MouseEvent) => {
     setIsHovered(true);
@@ -65,7 +66,7 @@ export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, on
         rx={6}
         fill={active ? "#1e293b" : "#0f172a"}
         fillOpacity={searchMatch ? 0.95 : isHovered ? 0.88 : highlighted ? 0.8 : dimmed ? 0.3 : 0.65}
-        stroke={searchMatch ? "#facc15" : "#fbbf24"}
+        stroke={accentColor}
         strokeWidth={searchMatch ? 2.5 : active ? 1.5 : 1}
         strokeOpacity={active ? 0.8 : dimmed ? 0.2 : 0.4}
         className={searchMatch ? "search-match-box" : undefined}
@@ -74,7 +75,7 @@ export function ArpDeviceNode({ node, highlighted, searchMatch, onMouseEnter, on
       <text
         x={x + 5}
         y={y + 12}
-        fill={searchMatch ? "#facc15" : "#fbbf24"}
+        fill={accentColor}
         fillOpacity={0.9}
         fontSize={searchMatch ? 9.5 : 8.5}
         fontWeight={searchMatch ? 700 : 600}

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -283,6 +283,9 @@ function DevicePopoverInner({ hostname, icon, screenX, screenY, bottomSheet, onM
                       </td>
                       <td className="py-0.5 px-2 font-mono text-gray-400">
                         <Copyable text={iface.mac} block>{iface.mac}</Copyable>
+                        {iface.vendor && (
+                          <div className="text-[10px] text-cyan-400 leading-tight truncate">{iface.vendor}</div>
+                        )}
                       </td>
                       <td className="py-0.5 px-2 font-mono text-gray-300 overflow-hidden">
                         {(() => {

--- a/frontend/src/components/DevicePopover.tsx
+++ b/frontend/src/components/DevicePopover.tsx
@@ -27,7 +27,7 @@ function formatUptime(seconds: number): string {
   return `${h}h ${m}m`;
 }
 
-function formatTimestamp(ts: string): string {
+export function formatTimestamp(ts: string): string {
   if (!ts) return "—";
   const d = new Date(ts.replace(" ", "T"));
   if (isNaN(d.getTime())) return ts;

--- a/frontend/src/components/LinkTooltip.tsx
+++ b/frontend/src/components/LinkTooltip.tsx
@@ -1,4 +1,5 @@
 import { Copyable } from "./Copyable";
+import { formatTimestamp } from "./DevicePopover";
 
 export interface LinkTooltipData {
   type: "lldp" | "arp" | "overlay" | "arp-device";
@@ -28,6 +29,8 @@ export interface LinkTooltipData {
   interface?: string;
   vendor?: string;
   sourceMac?: string;
+  stale?: boolean;
+  lastSeen?: string;
 }
 
 const OVERLAY_LABELS: Record<string, string> = {
@@ -92,6 +95,7 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
               <Row label="IP" value={data.targetIp ?? "—"} mono copyable />
             )}
             <Row label="MAC" value={data.mac ?? "—"} mono copyable />
+            {data.stale && data.lastSeen && <Row label="Last seen" value={formatTimestamp(data.lastSeen)} />}
           </tbody>
         </table>
       ) : data.type === "arp" ? (

--- a/frontend/src/components/LinkTooltip.tsx
+++ b/frontend/src/components/LinkTooltip.tsx
@@ -31,6 +31,7 @@ export interface LinkTooltipData {
   sourceMac?: string;
   stale?: boolean;
   lastSeen?: string;
+  sourceDown?: boolean;
 }
 
 const OVERLAY_LABELS: Record<string, string> = {
@@ -78,6 +79,7 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             {data.interface && <Row label="Interface" value={data.interface} mono />}
             {data.sourceIp && <Row label="IP" value={data.sourceIp} mono copyable />}
             {data.sourceMac && <Row label="MAC" value={data.sourceMac} mono copyable />}
+            {data.sourceDown && <Row label="Source" value="Device down — cached ARP" />}
             <SectionLabel label="Discovered device" />
             <Row label="Vendor" value={data.vendor || data.targetDisplayName || "Unknown"} />
             {data.targetIps && data.targetIps.length > 0 ? (
@@ -111,6 +113,7 @@ export function LinkTooltip({ data, onMouseEnter, onMouseLeave }: Props) {
             {data.targetInterface && <Row label="Interface" value={data.targetInterface} mono />}
             {data.targetIp && <Row label="IP" value={data.targetIp} mono copyable />}
             {data.targetMac && <Row label="MAC" value={data.targetMac} mono copyable />}
+            {data.sourceDown && <Row label="Source" value="Device down — cached ARP" />}
           </tbody>
         </table>
       ) : (

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -31,6 +31,7 @@ const LINK_HOVER_DELAY = 1000;
 
 const NEIGHBOR_COLOR = "#38bdf8";
 const ARP_COLOR = "#fbbf24";
+const ARP_SOURCE_DOWN_COLOR = "#f87171";
 const OVERLAY_PALETTE = [
   "#a78bfa", "#f472b6", "#34d399", "#fbbf24",
   "#60a5fa", "#fb923c", "#2dd4bf", "#c084fc",
@@ -1069,12 +1070,13 @@ export function TopologyMap({ data, sse }: Props) {
             if (sx == null || sy == null || tx == null || ty == null) return null;
             const key = `arp-${al.source.hostname}-${al.target.hostname}`;
             const linked = highlightedId === al.source.hostname || highlightedId === al.target.hostname;
+            const color = al.sourceDown ? ARP_SOURCE_DOWN_COLOR : ARP_COLOR;
             return (
               <HoverableLinkPath
                 key={key}
                 linkKey={key}
                 sx={sx} sy={sy} tx={tx} ty={ty}
-                color={ARP_COLOR}
+                color={color}
                 hovered={hoveredLinkKey === key}
                 highlighted={linked}
                 sourceSide={deviceSide.get(al.source.hostname)}
@@ -1087,13 +1089,14 @@ export function TopologyMap({ data, sse }: Props) {
                   targetHostname: al.target.hostname,
                   sourceDisplayName: displayName(al.source.hostname),
                   targetDisplayName: displayName(al.target.hostname),
-                  color: ARP_COLOR,
+                  color,
                   sourceIp: al.fromIp,
                   sourceInterface: al.fromInterface,
                   targetIp: al.toIp,
                   targetInterface: al.toInterface,
                   mac: formatMac(al.fromMac ?? al.mac),
                   targetMac: al.toMac ? formatMac(al.toMac) : undefined,
+                  sourceDown: al.sourceDown,
                 })}
                 onMouseLeave={hideLinkTooltip}
               />
@@ -1170,6 +1173,7 @@ export function TopologyMap({ data, sse }: Props) {
             const hovered = hoveredLinkKey === key;
             const linked = highlightedId === ad.seenByHostname || highlightedId === ad.mac;
             const parentDev = deviceMap.get(ad.seenByHostname);
+            const color = ad.sourceDown ? ARP_SOURCE_DOWN_COLOR : ARP_COLOR;
             return (
               <g key={key}>
                 {/* Wide invisible hit area */}
@@ -1187,7 +1191,7 @@ export function TopologyMap({ data, sse }: Props) {
                     targetHostname: ad.mac,
                     sourceDisplayName: displayName(ad.seenByHostname),
                     targetDisplayName: ad.vendor || "Unknown device",
-                    color: ARP_COLOR,
+                    color,
                     sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
                     targetIps: ad.ips,
                     mac: formatMac(ad.mac),
@@ -1196,12 +1200,13 @@ export function TopologyMap({ data, sse }: Props) {
                     vendor: ad.vendor,
                     stale: ad.stale,
                     lastSeen: ad.lastSeen,
+                    sourceDown: ad.sourceDown,
                   })}
                   onMouseLeave={hideLinkTooltip}
                 />
                 <path
                   d={d}
-                  stroke={ARP_COLOR}
+                  stroke={color}
                   strokeWidth={hovered || linked ? 2 : 1}
                   strokeOpacity={hovered || linked ? 0.9 : 0.35}
                   strokeDasharray="3 3"
@@ -1223,7 +1228,7 @@ export function TopologyMap({ data, sse }: Props) {
               targetHostname: ad.mac,
               sourceDisplayName: displayName(ad.seenByHostname),
               targetDisplayName: ad.vendor || "Unknown device",
-              color: ARP_COLOR,
+              color: ad.sourceDown ? ARP_SOURCE_DOWN_COLOR : ARP_COLOR,
               sourceIp: ad.seenByIp ?? parentDev?.lanIp ?? parentDev?.ip ?? "",
               targetIps: ad.ips,
               mac: formatMac(ad.mac),
@@ -1232,6 +1237,7 @@ export function TopologyMap({ data, sse }: Props) {
               vendor: ad.vendor,
               stale: ad.stale,
               lastSeen: ad.lastSeen,
+              sourceDown: ad.sourceDown,
             });
             return (
               <ArpDeviceNode

--- a/frontend/src/components/TopologyMap.tsx
+++ b/frontend/src/components/TopologyMap.tsx
@@ -1194,6 +1194,8 @@ export function TopologyMap({ data, sse }: Props) {
                     interface: ad.seenByInterface,
                     sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
                     vendor: ad.vendor,
+                    stale: ad.stale,
+                    lastSeen: ad.lastSeen,
                   })}
                   onMouseLeave={hideLinkTooltip}
                 />
@@ -1228,6 +1230,8 @@ export function TopologyMap({ data, sse }: Props) {
               interface: ad.seenByInterface,
               sourceMac: ad.seenByMac ? formatMac(ad.seenByMac) : undefined,
               vendor: ad.vendor,
+              stale: ad.stale,
+              lastSeen: ad.lastSeen,
             });
             return (
               <ArpDeviceNode

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -74,6 +74,8 @@ export interface ArpDeviceLayoutNode {
   seenByInterface?: string;
   seenByIp?: string;
   seenByMac?: string;
+  stale: boolean;
+  lastSeen: string;
   x: number;
   y: number;
 }
@@ -374,6 +376,8 @@ function layoutAll(
           seenByInterface: ad.seenByInterface,
           seenByIp: ad.seenByIp,
           seenByMac: ad.seenByMac,
+          stale: ad.stale,
+          lastSeen: ad.lastSeen,
           x: arpStartX + ARP_NODE_W / 2 + col * (ARP_NODE_W + ARP_NODE_GAP_X),
           y: arpStartY + ARP_SECTION_LABEL_H + ARP_SECTION_PAD + ARP_NODE_H / 2 + row * (ARP_NODE_H + ARP_NODE_GAP_Y),
         });

--- a/frontend/src/hooks/useForceLayout.ts
+++ b/frontend/src/hooks/useForceLayout.ts
@@ -44,6 +44,7 @@ export interface ArpLayoutLink {
   fromMac?: string;
   toInterface?: string;
   toMac?: string;
+  sourceDown: boolean;
 }
 
 export interface SiteCluster {
@@ -76,6 +77,7 @@ export interface ArpDeviceLayoutNode {
   seenByMac?: string;
   stale: boolean;
   lastSeen: string;
+  sourceDown: boolean;
   x: number;
   y: number;
 }
@@ -378,6 +380,7 @@ function layoutAll(
           seenByMac: ad.seenByMac,
           stale: ad.stale,
           lastSeen: ad.lastSeen,
+          sourceDown: ad.sourceDown,
           x: arpStartX + ARP_NODE_W / 2 + col * (ARP_NODE_W + ARP_NODE_GAP_X),
           y: arpStartY + ARP_SECTION_LABEL_H + ARP_SECTION_PAD + ARP_NODE_H / 2 + row * (ARP_NODE_H + ARP_NODE_GAP_Y),
         });
@@ -439,6 +442,7 @@ function layoutAll(
         fromMac: a.fromMac,
         toInterface: a.toInterface,
         toMac: a.toMac,
+        sourceDown: a.sourceDown,
       });
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.19.19)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
 
   frontend:
     dependencies:
@@ -380,6 +383,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/core-darwin-arm64@1.15.40':
     resolution: {integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==}
     engines: {node: '>=10'}
@@ -602,8 +608,17 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-force@3.0.10':
     resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
@@ -624,6 +639,46 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
@@ -659,10 +714,20 @@ packages:
     resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -782,6 +847,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -820,9 +892,18 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
@@ -831,9 +912,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -898,6 +990,52 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
 snapshots:
 
@@ -1078,6 +1216,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/core-darwin-arm64@1.15.40':
     optional: true
 
@@ -1245,7 +1385,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-force@3.0.10': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@22.19.19':
     dependencies:
@@ -1269,6 +1418,53 @@ snapshots:
       vite: 8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
 
@@ -1294,6 +1490,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -1323,6 +1521,12 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1400,6 +1604,10 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -1451,16 +1659,28 @@ snapshots:
 
   seroval@1.5.4: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1:
     optional: true
@@ -1492,3 +1712,35 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
+
+  vitest@4.1.9(@types/node@22.19.19)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -187,6 +187,7 @@ export interface TopologyResponse {
 export interface DeviceInterface {
   ifName: string;
   mac: string;
+  vendor: string;
   ifOperStatus: string;
   ips: string[];
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -160,6 +160,9 @@ export interface ArpDiscoveredDevice {
   seenByInterface?: string;
   seenByIp?: string;
   seenByMac?: string;
+  firstSeen: string; // ISO 8601
+  lastSeen: string;  // ISO 8601
+  stale: boolean;
 }
 
 export interface TopologyResponse {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -147,6 +147,10 @@ export interface ArpLink {
   fromMac?: string;
   toInterface?: string;
   toMac?: string;
+  // True when the managed device that reported this ARP sighting (toHostname)
+  // is currently down (enabled in LibreNMS but unreachable) — its ARP table
+  // may be a stale cache from before it went down.
+  sourceDown: boolean;
 }
 
 export interface ArpDiscoveredDevice {
@@ -163,6 +167,10 @@ export interface ArpDiscoveredDevice {
   firstSeen: string; // ISO 8601
   lastSeen: string;  // ISO 8601
   stale: boolean;
+  // True when every managed device that currently sources this discovered
+  // device is down. A device seen by at least one up source is never marked
+  // sourceDown, even if other sources are down.
+  sourceDown: boolean;
 }
 
 export interface TopologyResponse {


### PR DESCRIPTION
## Summary
- A device discovered via ARP/ND (e.g. powered off temporarily in a home lab) no longer vanishes from the topology the instant it misses one poll — it now dims for 15 minutes as "stale" and is only fully removed after 24 hours of no reconfirmation.
- Adds `firstSeen`/`lastSeen`/`stale` to `ArpDiscoveredDevice`, backed by a new in-memory `ArpDeviceRegistry` that upserts by MAC instead of the previous "overwrite the whole array every poll cycle" pattern.
- Fixes a real bug found during design review: the discovered-device add/remove toast diff was computed from a snapshot that never observed 24h eviction, so a "removed" toast could never actually fire — it's now computed after eviction, inside `buildAndCacheTopology()`.
- Frontend: a stale device's node dims (still fully interactive on hover) and its tooltip shows a "Last seen" row.
- Adds `sourceDown` to `ArpLink`/`ArpDiscoveredDevice`: LibreNMS keeps a device's cached ARP table even after it goes down, so entries sourced only from an enabled-but-unreachable device kept looking freshly-seen forever. Now flagged (red accent on links/boxes/tooltip) instead of excluded outright — a device seen by at least one currently-up source is never flagged, even if other sources are down.
- Fixes a race in `pollNdNeighbours`: its managed-MAC exclusion lookup relied on the ports cache, which shares a 5-minute TTL with the poll interval itself. Ports get cached mid-way through `warmCache()`, before `pollRoutes` and the first ND poll consume more time — so by the time the periodic timers were registered, every device's cache entry was already closer to expiry, and it would silently expire before the very next periodic ND cycle, causing that device's own interface MACs to be misclassified as "unmanaged" discovered devices. Now falls back to a live ports fetch when the cache entry is missing, matching the existing ARP-link exclusion pattern.
- Adds interface vendor (OUI lookup) under the MAC address in the device popover's Interfaces table, styled to match the Routes table's next-hop device name.

## Design & Plan
- Spec: `docs/superpowers/specs/2026-07-03-discovered-device-lastseen-staleness-design.md`
- Plan: `docs/superpowers/plans/2026-07-03-discovered-device-lastseen-staleness.md`

## Test plan
- [x] `cd backend && npx vitest run` — 5/5 passing (registry upsert/stale/eviction/revive behavior, real assertions no mocks)
- [x] `cd backend && npx tsc --noEmit` — 0 errors
- [x] `cd frontend && npx tsc -b` — 0 errors
- [x] `docker-compose up -d --build` — build succeeds, container stays up
- [x] Verified live against the real LibreNMS instance: poller logs show the new registry-based flow (`[poller] ARP: upserted 128 discovered devices...`, `[poller] ND: 413 entries scanned...`), and `/api/topology` returns correct `firstSeen`/`lastSeen`/`stale` fields
- [x] Proved the stale transition live: a device's `stale` field flips `false` → `true` after its threshold elapses with no reconfirming poll (temporarily lowered threshold for speed, cleanly reverted)
- [x] `sourceDown`: cross-checked all discovered devices/ARP links against real LibreNMS device status; confirmed devices sourced only by down-but-enabled managed devices are correctly flagged
- [x] ND race fix: reproduced the original bug live (10 phantom discovered devices from managed MACs on the first periodic ND cycle after a restart), applied the fix, restarted, and confirmed 0 phantom entries across two consecutive cycles including the exact race window
- [x] Interface vendor: verified via `/api/devices/{hostname}/overview` that vendor is populated for OUI-registered MACs and empty for locally-administered ones; confirmed the rendering code shipped in the built bundle
- [ ] Visual browser check of dimming/tooltip/vendor rendering — not done in this session (browser automation unavailable); recommend a quick manual pass before merging

Built via subagent-driven development: 5 implementation tasks, each independently reviewed (spec compliance + code quality, all approved), plus a final whole-branch review (ready to merge, no Critical/Important issues — two trivial polish suggestions were applied in the last commit). The `sourceDown`, ND-race fix, and interface-vendor changes were added afterward as follow-up work on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)